### PR TITLE
Correctly handle JDBC urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Release 1.0.1 (December 4, 2018)
+### Release 1.0.1 (December 5, 2018)
 * Fixed an issue with the way JDBC URLs are handled:
   * acceptsURL() now returns false if the URL is a JDBC URL that does not begin with jdbc-secretsmanager
   * connect() returns null if the URL parameter is not one we accept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+### Release 1.0.1 (December 4, 2018)
+* Fixed an issue with the way JDBC URLs are handled:
+  * acceptsURL() now returns false if the URL is a JDBC URL that does not begin with jdbc-secretsmanager
+  * connect() returns null if the URL parameter is not one we accept
+* Updated jackson-databind dependency to 2.8.11.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The recommended way to use the SQL Connection Library is to consume it from Mave
 <dependency>
     <groupId>com.amazonaws.secretsmanager</groupId>
     <artifactId>aws-secretsmanager-jdbc</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <aws-java-sdk.version>1.11.418</aws-java-sdk.version>
     <aws-secretsmanager-cache.version>1.0.0</aws-secretsmanager-cache.version>
     <lombok.version>1.16.20</lombok.version>
-    <jackson.version>2.6.7</jackson.version>
+    <jackson.version>2.8.11.1</jackson.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.6</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <artifactId>aws-secretsmanager-jdbc</artifactId>
   <packaging>jar</packaging>
   <name>AWS Secrets Manager SQL Connection Library</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>The AWS Secrets Manager SQL Connection Library for Java enables Java developers to easily
     connect to SQL databases using secrets stored in AWS Secrets Manager.
   </description>
@@ -237,7 +237,7 @@
             <configuration>
               <serverId>sonatype-nexus-staging</serverId>
               <nexusUrl>https://oss.sonatype.org</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
         </plugins>

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -248,8 +248,11 @@ public abstract class AWSSecretsManagerDriver implements Driver {
         }
 
         if (url.startsWith(SCHEME)) {
-            // If this is a URL in our SCHEME, call the accpetsURL method of the wrapped driver
+            // If this is a URL in our SCHEME, call the acceptsURL method of the wrapped driver
             return getWrappedDriver().acceptsURL(unwrapUrl(url));
+        } else if (url.startsWith("jdbc:")) {
+            // For any other JDBC URL, return false
+            return false;
         } else  {
             // We accept a secret ID as the URL so if the config is set, and it's not a JDBC URL, return true
             return true;
@@ -342,8 +345,8 @@ public abstract class AWSSecretsManagerDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
-        if (url == null) {
-            throw new SQLException("url cannot be null.");
+        if (!acceptsURL(url)) {
+            return null;
         }
 
         String unwrappedUrl = "";

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -13,6 +13,7 @@
 package com.amazonaws.secretsmanager.sql;
 
 
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
@@ -181,6 +182,12 @@ public class AWSSecretsManagerDriverTest extends TestClass {
     }
 
     @Test
+    public void test_acceptsURL_returnsFalse_JdbcUrl() {
+        assertNotThrows(() -> assertFalse(sut.acceptsURL("jdbc:expectedUrl")));
+        assertEquals(0, DummyDriver.acceptsURLCallCount);
+    }
+
+    @Test
     public void test_acceptsURL_returnsTrue_secretId() {
         assertNotThrows(() -> assertTrue(sut.acceptsURL("someSecretId")));
         assertEquals(0, DummyDriver.acceptsURLCallCount);
@@ -214,6 +221,12 @@ public class AWSSecretsManagerDriverTest extends TestClass {
         props.setProperty("user", "user");
         assertNotThrows(() -> sut.connect("jdbc-secretsmanager:expectedUrl", props));
         assertEquals(1, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_jdbc_returnsNull() throws SQLException {
+        Connection conn = sut.connect("jdbc:expectedUrl", null);
+        assertEquals(conn, null);
     }
 
     @Test


### PR DESCRIPTION
Issue #2: Driver attempts to connect to non-secretsmanager JDBC URLs

Description of changes: Do not accept JDBC URLs that do not begin with our jdbc-secretsmanager scheme. Also, return null on connect() if we do not accept the URL.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
