### PR TITLE
update default driver class for MySQL

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
@@ -128,6 +128,6 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
 
     @Override
     public String getDefaultDriverClass() {
-        return "com.mysql.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
     }
 }


### PR DESCRIPTION
MySQL Connector/J has changed from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver. The old class name is deprecated.

https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-api-changes.html