### PR TITLE
Added support for MariaDB Connector/J

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.secretsmanager.sql;
+
+import java.sql.SQLException;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.util.StringUtils;
+
+/**
+ * <p>
+ * Provides support for accessing MariaDB databases using credentials stored within AWS Secrets Manager.
+ * </p>
+ *
+ * <p>
+ * This will also work for MariaDB, as the error codes are the same.
+ * </p>
+ *
+ * <p>
+ * Configuration properties are specified using the "mariadb" subprefix (e.g drivers.mariadb.realDriverClass).
+ * </p>
+ */
+public final class AWSSecretsManagerMariaDBDriver extends AWSSecretsManagerDriver {
+
+    /**
+     * MariaDB shares error codes with MySQL, as well as adding a number of new error codes specific to MariaDB.
+     *
+     * See <a href="https://mariadb.com/kb/en/library/mariadb-error-codes/">MariaDB error codes</a>.
+     */
+    public static final int ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = 1045;
+
+    /**
+     * Set to mariadb.
+     */
+    public static final String SUBPREFIX = "mariadb";
+
+    static {
+        AWSSecretsManagerDriver.register(new AWSSecretsManagerMariaDBDriver());
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with default options.
+     */
+    public AWSSecretsManagerMariaDBDriver() {
+        super();
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Uses the passed in SecretCache.
+     *
+     * @param cache                                             Secret cache to use to retrieve secrets
+     */
+    public AWSSecretsManagerMariaDBDriver(SecretCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the passed in client builder.
+     *
+     * @param builder                                           Builder used to instantiate cache
+     */
+    public AWSSecretsManagerMariaDBDriver(AWSSecretsManagerClientBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the provided AWS Secrets Manager client.
+     *
+     * @param client                                            AWS Secrets Manager client to instantiate cache
+     */
+    public AWSSecretsManagerMariaDBDriver(AWSSecretsManager client) {
+        super(client);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the provided cache configuration.
+     *
+     * @param cacheConfig                                       Cache configuration to instantiate cache
+     */
+    public AWSSecretsManagerMariaDBDriver(SecretCacheConfiguration cacheConfig) {
+        super(cacheConfig);
+    }
+
+    @Override
+    public String getPropertySubprefix() {
+        return SUBPREFIX;
+    }
+
+    @Override
+    public boolean isExceptionDueToAuthenticationError(Exception e) {
+        if (e instanceof SQLException) {
+            SQLException sqle = (SQLException) e;
+            int errorCode = sqle.getErrorCode();
+            return errorCode == ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE;
+        }
+        return false;
+    }
+
+    @Override
+    public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
+        String url = "jdbc:mariadb://" + endpoint;
+        if (!StringUtils.isNullOrEmpty(port)) {
+            url += ":" + port;
+        }
+        if (!StringUtils.isNullOrEmpty(dbname)) {
+            url += "/" + dbname;
+        }
+        return url;
+    }
+
+    @Override
+    public String getDefaultDriverClass() {
+        return "org.mariadb.jdbc.Driver";
+    }
+}

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -43,6 +43,7 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
  */
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor({"com.amazonaws.secretsmanager.sql.AWSSecretsManagerMSSQLServerDriver",
+    "com.amazonaws.secretsmanager.sql.AWSSecretsManagerMariaDBDriver",
     "com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver",
     "com.amazonaws.secretsmanager.sql.AWSSecretsManagerOracleDriver",
     "com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver"})

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.secretsmanager.sql;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.Before;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.util.TestClass;
+
+/**
+ * Tests for the MariaDB Driver.
+ */
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMariaDBDriver")
+public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
+
+    private AWSSecretsManagerMariaDBDriver sut;
+
+    @Mock
+    private SecretCache cache;
+
+    @Before
+    public void setup() {
+        System.setProperty("drivers.mariadb.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
+        MockitoAnnotations.initMocks(this);
+        try {
+            sut = new AWSSecretsManagerMariaDBDriver(cache);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void test_getPropertySubprefix() {
+        assertEquals("mariadb", sut.getPropertySubprefix());
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctException() {
+        SQLException e = new SQLException("", "", 1045);
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
+        SQLException e = new SQLException("", "", 1046);
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_runtimeException() {
+        RuntimeException e = new RuntimeException("asdf");
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_constructUrl() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", "dev");
+        assertEquals(url, "jdbc:mariadb://test-endpoint:1234/dev");
+    }
+
+    @Test
+    public void test_constructUrlNullPort() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", null, "dev");
+        assertEquals(url, "jdbc:mariadb://test-endpoint/dev");
+    }
+
+    @Test
+    public void test_constructUrlNullDatabase() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", null);
+        assertEquals(url, "jdbc:mariadb://test-endpoint:1234");
+    }
+
+    @Test
+    public void test_getDefaultDriverClass() {
+        System.clearProperty("drivers.mariadb.realDriverClass");
+        AWSSecretsManagerMariaDBDriver sut2 = new AWSSecretsManagerMariaDBDriver(cache);
+        assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
+    }
+}
+


### PR DESCRIPTION
This PR adds AWSSecretsManagerMariaDBDriver which is almost identical to AWSSecretsManagerMySQLDriver.java.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.