### PR TITLE
Use current MySQL driver if on classpath

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
@@ -128,6 +128,11 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
 
     @Override
     public String getDefaultDriverClass() {
-        return "com.mysql.jdbc.Driver";
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver", false, this.getClass().getClassLoader());
+            return "com.mysql.cj.jdbc.Driver";
+        } catch (ClassNotFoundException e) {
+            return "com.mysql.jdbc.Driver";
+        }
     }
 }


### PR DESCRIPTION
I would like to propose this as an alternative to https://github.com/aws/aws-secretsmanager-jdbc/pull/6

An attempt is made to load the current MySQL driver on the classpath to determine which driver class to return.