### PR TITLE
Don't require secret id in user if already given in jdbc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,5 @@ The secret being used should be in the JSON format we use for our rotation lambd
 	...
 }
 ```
+
+Alternatively, you can pass the secret ID as the jdbc uri and omit user. The JDBC connection details such as host, port, dbname will be obtained from your secrets manager secret.

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -231,9 +231,8 @@ public class AWSSecretsManagerDriverTest extends TestClass {
     }
 
     @Test
-    public void test_connect_works_secretId() {
+    public void test_connect_works_secretId_in_url() {
         Properties props = new Properties();
-        props.setProperty("user", "user");
         assertNotThrows(() -> sut.connect("someSecretId", props));
         assertEquals(1, DummyDriver.connectCallCount);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, the jdbc url can be a secret id, which is great, as it saves having to duplicate all the connection details already stored in secrets manager to build a full jdbc url. User, however, is still required to be passed in, and is also required to be a secret id, so just duplicates the one passed in under jdbc url. This change means that if the jdbc url is a secret id, you do not need to pass the secret id in again as user.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
