### PR TITLE
Check MySQL exception causes for auth error

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
@@ -106,11 +106,21 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
 
     @Override
     public boolean isExceptionDueToAuthenticationError(Exception e) {
-        if (e instanceof SQLException) {
-            SQLException sqle = (SQLException) e;
-            int errorCode = sqle.getErrorCode();
-            return errorCode == ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE;
-        }
+        Throwable t = e;
+        do {
+            if (t instanceof SQLException) {
+                SQLException sqle = (SQLException) t;
+                int errorCode = sqle.getErrorCode();
+                if (errorCode == ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) {
+                    return true;
+                } else {
+                    t = t.getCause();
+                }
+            } else {
+                t = t.getCause();
+            }
+        } while (t != null);
+
         return false;
     }
 

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
@@ -63,10 +63,26 @@ public class AWSSecretsManagerMySQLDriverTest extends TestClass {
     }
 
     @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctWrappedException() {
+        SQLException e = new SQLException("", "", 1045);
+        SQLException wrapper = new SQLException("", "", 0, e);
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(wrapper));
+    }
+
+    @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
         SQLException e = new SQLException("", "", 1046);
 
         assertFalse(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongWrappedSQLException() {
+        SQLException e = new SQLException("", "", 1046);
+        SQLException wrapper = new SQLException("", "", 0, e);
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(wrapper));
     }
 
     @Test


### PR DESCRIPTION
Can sometimes get wrapped with another exception so can't
just looked at the top level.

*Issue #, if available:*

*Description of changes:*

Depending on what connection options are provided to MySQL, you don't always just get back a SQLException containing the error code that identifies an auth error. In my case, as my app has some autoReconnect / maxReconnects options set, I was seeing the SQLException wrapped in a com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException. To remedy this, this PR changes the error code checking to not only check the current exception, but to recursively check causes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.