### PR TITLE
Added secret region override via env variable (#27).

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -115,9 +115,12 @@ public abstract class AWSSecretsManagerDriver implements Driver {
     /**
      * Constructs the driver setting the properties from the properties file using system properties as defaults.
      * Instantiates the secret cache with default options.
+     * AWS_SECRET_JDBC_REGION environment variable can be provided to override the region in the secret cache.
      */
     protected AWSSecretsManagerDriver() {
-        this(new SecretCache());
+        this(System.getenv("AWS_SECRET_JDBC_REGION") == null ? new SecretCache() :
+             new SecretCache(AWSSecretsManagerClientBuilder.standard().
+                 withRegion(System.getenv("AWS_SECRET_JDBC_REGION"))));
     }
 
     /**


### PR DESCRIPTION
*Issue #27*
*Description of changes:* Added the ability to override the AWS region used by the SecretsManagerClient in the SecretCache via environment variable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.