### PR TITLE
Load real driver class before use

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -177,6 +177,20 @@ public abstract class AWSSecretsManagerDriver implements Driver {
     }
 
     /**
+     * Loads the real driver.
+     *
+     * @throws IllegalStateException                            When there is no class with the name
+     *                                                          <code>realDriverClass</code>
+     */
+    private void loadRealDriver() {
+        try {
+            Class.forName(this.realDriverClass);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Could not load real driver with name, \"" + this.realDriverClass + "\".", e);
+        }
+    }
+
+    /**
      * Called when the driver is deregistered to cleanup resources.
      */
     private static void shutdown(AWSSecretsManagerDriver driver) {
@@ -234,6 +248,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      *                                                          <code>realDriverClass</code>
      */
     public Driver getWrappedDriver() {
+        loadRealDriver();
         Enumeration<Driver> availableDrivers = DriverManager.getDrivers();
         while (availableDrivers.hasMoreElements()) {
             Driver driver = availableDrivers.nextElement();


### PR DESCRIPTION
*Issue #, if available:* #26 

*Description of changes:*
Load the real driver before it is used by calling `Class.forName(this.realDriverClass)`. This ensures that the real driver has an opportunity to be registered.

If the real driver class does not exist, an `IllegalStateException` is thrown. This exception matches the `assertThrows` tested by `AWSSecretsManagerDriverTest.test_getWrappedDriver_throws_badDriver`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
