### PR TITLE
Use current thread resource context instead of system one

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -67,7 +67,7 @@ public final class Config {
     private static Properties loadPropertiesFromConfigFile(String resourceName) {
         Properties newConfig = new Properties(System.getProperties());
 
-        try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
+        try (InputStream configFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
             if (configFile != null) {
                 newConfig.load(configFile);
                 configFile.close();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change will allow the Config to be able to load resources if they arent on the system classpath, for instance, on a war deployed file, where the classloader cant see the secretsmanager.properties file because its only on the app classpath and not on the system one. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
