### PR TITLE
Sonar Issue - Remove useless invocation of InputStream#close()

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -70,7 +70,6 @@ public final class Config {
         try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
             if (configFile != null) {
                 newConfig.load(configFile);
-                configFile.close();
             }
         } catch (IOException e) {
             throw new PropertyException("An error occured when loading the property file, " + CONFIG_FILE_NAME, e);


### PR DESCRIPTION
*Description of changes:*
Config - Remove useless invocation of InputStream#close() in try-with-resources, detected by SonarLint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
