### PR TITLE
gitignore - Eclipse, InteliJ, Maven, Checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Maven Build files
+/target/
+
+# InteliJ IDEA files
+.DS_Store
+.idea
+
+# Eclipse IDE files
+.project
+.classpath
+.settings
+
+# Checkstyle local config file
+.checkstyle


### PR DESCRIPTION
*Description of changes:*
Small improvement - gitignore configred for InteliJ IDEA, Eclipse IDE, Checkstyle, Maven in order to avoid developers to accidentally commit local build/config files to repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
