### PR TITLE
Allowing use of newer versions of AWS Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <url>https://aws.amazon.com/secrets-manager</url>
 
   <properties>
-    <aws-java-sdk.version>1.11.418</aws-java-sdk.version>
+    <aws-java-sdk.version>[1.11.418,)</aws-java-sdk.version>
     <aws-secretsmanager-cache.version>1.0.1</aws-secretsmanager-cache.version>
     <lombok.version>1.16.20</lombok.version>
     <jackson.version>2.10.3</jackson.version>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allowing aws-java-sdk version 1.11.418 or greater. Tested with aws-java-sdk 1.11.806 (newest release)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
