### PR TITLE
Fix build issues in JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
     <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-    <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+    <spotbugs.plugin.version>4.5.0.0</spotbugs.plugin.version>
+    <spotbugs.version>4.5.1</spotbugs.version>
   </properties>
 
   <licenses>
@@ -196,7 +197,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
+      <!-- <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs.plugin.version}</version>
@@ -214,6 +215,33 @@
             </goals>
           </execution>
         </executions>
+      </plugin> -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs.plugin.version}</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+        <executions>
+          <execution>
+            <id>analyze-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${spotbugs.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,16 +27,17 @@
   <properties>
     <aws-java-sdk.version>[1.11.418,)</aws-java-sdk.version>
     <aws-secretsmanager-cache.version>1.0.1</aws-secretsmanager-cache.version>
-    <lombok.version>1.16.20</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <jackson.version>2.10.5.1</jackson.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.6</powermock.version>
+    <mockito_core.version>2.22.0</mockito_core.version>
+    <powermock.version>2.0.9</powermock.version>
     <compiler.plugin.version>3.2</compiler.plugin.version>
     <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-    <findbugs.plugin.version>3.0.4</findbugs.plugin.version>
+    <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
   </properties>
 
   <licenses>
@@ -107,6 +108,13 @@
     </dependency>
 
     <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito_core.version}</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>${mockito.version}</version>
@@ -122,7 +130,7 @@
 
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -68,12 +68,11 @@ public final class Config {
         Properties newConfig = new Properties(System.getProperties());
 
         try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
-            if (configFile != null) {
-                newConfig.load(configFile);
-                configFile.close();
-            }
+            newConfig.load(configFile);
         } catch (IOException e) {
             throw new PropertyException("An error occured when loading the property file, " + CONFIG_FILE_NAME, e);
+        } catch (NullPointerException e) {
+            // This is to fix findbug's RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE without failing ConfigTest.test_loadConfigFrom_badFile test
         }
         return newConfig;
     }

--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -67,13 +67,13 @@ public final class Config {
     private static Properties loadPropertiesFromConfigFile(String resourceName) {
         Properties newConfig = new Properties(System.getProperties());
 
-        try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
-            newConfig.load(configFile);
+        try (InputStream configFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+            if (configFile != null) {  
+                newConfig.load(configFile);
+            }
         } catch (IOException e) {
             throw new PropertyException("An error occured when loading the property file, " + CONFIG_FILE_NAME, e);
-        } catch (NullPointerException e) {
-            // This is to fix findbug's RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE without failing ConfigTest.test_loadConfigFrom_badFile test
-        }
+        } 
         return newConfig;
     }
 


### PR DESCRIPTION
Fixes Issue #9 and Issue #63.

Updating lombok, powermock and mockito to latest version fixes compile errors in JDK11. But findbug plugin generates false positive RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE. It is apparently a bug in findbug plugin which is outdated and deprecated. Switching to its successor spotbugs fixes the problem.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
