### PR TITLE
Add Redshift driver

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,17 @@
+name: Java Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots package

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS Secrets Manager JDBC Library
 
+![build](https://github.com/aws/aws-secretsmanager-jdbc/actions/workflows/CI.yml/badge.svg)
+
 The **AWS Secrets Manager JDBC Library** enables Java developers to easily connect to SQL databases using secrets stored in AWS Secrets Manager.
 
 ## License
@@ -22,7 +24,7 @@ The recommended way to use the SQL Connection Library is to consume it from Mave
 <dependency>
     <groupId>com.amazonaws.secretsmanager</groupId>
     <artifactId>aws-secretsmanager-jdbc</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,13 @@
  ~  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  ~  and limitations under the License.
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws.secretsmanager</groupId>
   <artifactId>aws-secretsmanager-jdbc</artifactId>
   <packaging>jar</packaging>
   <name>AWS Secrets Manager SQL Connection Library</name>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <description>The AWS Secrets Manager SQL Connection Library for Java enables Java developers to easily
     connect to SQL databases using secrets stored in AWS Secrets Manager.
   </description>
@@ -27,16 +25,17 @@
   <properties>
     <aws-java-sdk.version>1.12.148</aws-java-sdk.version>
     <aws-secretsmanager-cache.version>1.0.2</aws-secretsmanager-cache.version>
-    <lombok.version>1.16.20</lombok.version>
-    <jackson.version>2.10.5.1</jackson.version>
-    <junit.version>4.11</junit.version>
+    <lombok.version>1.18.24</lombok.version>
+    <jackson.version>2.13.2.2</jackson.version>
+    <junit.version>4.13.1</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.6</powermock.version>
     <compiler.plugin.version>3.2</compiler.plugin.version>
     <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-    <findbugs.plugin.version>3.0.4</findbugs.plugin.version>
+    <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <licenses>

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.secretsmanager.sql;
+
+import java.sql.SQLException;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.util.StringUtils;
+
+/**
+ * <p>
+ * Provides support for accessing Redshift databases using credentials stored
+ * within AWS Secrets Manager.
+ * </p>
+ *
+ * <p>
+ * Configuration properties are specified using the "redshift" subprefix (e.g
+ * drivers.redshift.realDriverClass).
+ * </p>
+ */
+public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriver {
+
+    /**
+     * The Redshift error code for when a user logs in using an invalid password.
+     *
+     * See <a href=
+     * "https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html">Postgres documentation</a> (Redshift is built on Postgres).
+     */
+    public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
+
+    public static final String SUBPREFIX = "redshift";
+
+    static {
+        AWSSecretsManagerDriver.register(new AWSSecretsManagerRedshiftDriver());
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using
+     * system properties as defaults.
+     * Instantiates the secret cache with default options.
+     */
+    public AWSSecretsManagerRedshiftDriver() {
+        super();
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using
+     * system properties as defaults.
+     * Uses the passed in SecretCache.
+     *
+     * @param cache Secret cache to use to retrieve secrets
+     */
+    public AWSSecretsManagerRedshiftDriver(SecretCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using
+     * system properties as defaults.
+     * Instantiates the secret cache with the passed in client builder.
+     *
+     * @param builder Builder used to instantiate cache
+     */
+    public AWSSecretsManagerRedshiftDriver(AWSSecretsManagerClientBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using
+     * system properties as defaults.
+     * Instantiates the secret cache with the provided AWS Secrets Manager client.
+     *
+     * @param client AWS Secrets Manager client to instantiate cache
+     */
+    public AWSSecretsManagerRedshiftDriver(AWSSecretsManager client) {
+        super(client);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using
+     * system properties as defaults.
+     * Instantiates the secret cache with the provided cache configuration.
+     *
+     * @param cacheConfig Cache configuration to instantiate cache
+     */
+    public AWSSecretsManagerRedshiftDriver(SecretCacheConfiguration cacheConfig) {
+        super(cacheConfig);
+    }
+
+    @Override
+    public String getPropertySubprefix() {
+        return SUBPREFIX;
+    }
+
+    @Override
+    public boolean isExceptionDueToAuthenticationError(Exception e) {
+        if (e instanceof SQLException) {
+            SQLException sqle = (SQLException) e;
+            String sqlState = sqle.getSQLState();
+            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE);
+        }
+        return false;
+    }
+
+    @Override
+    public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
+        String url = "jdbc:redshift://" + endpoint;
+        if (!StringUtils.isNullOrEmpty(port)) {
+            url += ":" + port;
+        }
+        if (!StringUtils.isNullOrEmpty(dbname)) {
+            url += "/" + dbname;
+        }
+        return url;
+    }
+
+    @Override
+    public String getDefaultDriverClass() {
+        return "com.amazon.redshift.jdbc42.Driver";
+    }
+}

--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -67,8 +67,11 @@ public final class Config {
     private static Properties loadPropertiesFromConfigFile(String resourceName) {
         Properties newConfig = new Properties(System.getProperties());
 
-        try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
-            if (configFile != null) {
+        InputStream configFile;
+
+        try {
+            configFile = ClassLoader.getSystemResourceAsStream(resourceName);
+            if(configFile != null) {
                 newConfig.load(configFile);
                 configFile.close();
             }

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Before;
@@ -42,11 +43,8 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
  * the file.
  */
 @RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor({"com.amazonaws.secretsmanager.sql.AWSSecretsManagerMSSQLServerDriver",
-    "com.amazonaws.secretsmanager.sql.AWSSecretsManagerMariaDBDriver",
-    "com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver",
-    "com.amazonaws.secretsmanager.sql.AWSSecretsManagerOracleDriver",
-    "com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver"})
+@SuppressStaticInitializationFor({"com.amazonaws.secretsmanager.sql.*"})
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerDriverTest extends TestClass {
 
     private AWSSecretsManagerDummyDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Before;
@@ -32,6 +33,7 @@ import com.amazonaws.secretsmanager.util.TestClass;
  */
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMSSQLServerDriver")
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
 
     private AWSSecretsManagerMSSQLServerDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Before;
@@ -32,6 +33,7 @@ import com.amazonaws.secretsmanager.util.TestClass;
  */
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMariaDBDriver")
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
 
     private AWSSecretsManagerMariaDBDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Before;
@@ -32,6 +33,7 @@ import com.amazonaws.secretsmanager.util.TestClass;
  */
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver")
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMySQLDriverTest extends TestClass {
 
     private AWSSecretsManagerMySQLDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Before;
@@ -32,6 +33,7 @@ import com.amazonaws.secretsmanager.util.TestClass;
  */
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver")
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
 
     private AWSSecretsManagerPostgreSQLDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
@@ -29,24 +29,24 @@ import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
 
 /**
- * Tests for the Oracle Driver.
+ * Tests for the Redshift Driver.
  */
 @RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerOracleDriver")
+@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerRedshiftDriver")
 @PowerMockIgnore("jdk.internal.reflect.*")
-public class AWSSecretsManagerOracleDriverTest extends TestClass {
+public class AWSSecretsManagerRedshiftDriverTest extends TestClass {
 
-    private AWSSecretsManagerOracleDriver sut;
+    private AWSSecretsManagerRedshiftDriver sut;
 
     @Mock
     private SecretCache cache;
 
     @Before
     public void setup() {
-        System.setProperty("drivers.oracle.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
+        System.setProperty("drivers.redshift.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.initMocks(this);
         try {
-            sut = new AWSSecretsManagerOracleDriver(cache);
+            sut = new AWSSecretsManagerRedshiftDriver(cache);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -54,24 +54,19 @@ public class AWSSecretsManagerOracleDriverTest extends TestClass {
 
     @Test
     public void test_getPropertySubprefix() {
-        assertEquals("oracle", sut.getPropertySubprefix());
+        assertEquals("redshift", sut.getPropertySubprefix());
     }
 
     @Test
-    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctExceptions() {
-        SQLException e = new SQLException("", "", 17079);
-        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctException() {
+        SQLException e = new SQLException("", "28P01");
 
-        e = new SQLException("", "", 1017);
-        assertTrue(sut.isExceptionDueToAuthenticationError(e));
-
-        e = new SQLException("", "", 9911);
         assertTrue(sut.isExceptionDueToAuthenticationError(e));
     }
 
     @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
-        SQLException e = new SQLException("", "", 1046);
+        SQLException e = new SQLException("", "28P02");
 
         assertFalse(sut.isExceptionDueToAuthenticationError(e));
     }
@@ -86,26 +81,25 @@ public class AWSSecretsManagerOracleDriverTest extends TestClass {
     @Test
     public void test_constructUrl() {
         String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", "dev");
-        assertEquals(url, "jdbc:oracle:thin:@//test-endpoint:1234/dev");
+        assertEquals(url, "jdbc:redshift://test-endpoint:1234/dev");
     }
 
     @Test
     public void test_constructUrlNullPort() {
         String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", null, "dev");
-        assertEquals(url, "jdbc:oracle:thin:@//test-endpoint/dev");
+        assertEquals(url, "jdbc:redshift://test-endpoint/dev");
     }
 
     @Test
     public void test_constructUrlNullDatabase() {
         String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", null);
-        assertEquals(url, "jdbc:oracle:thin:@//test-endpoint:1234");
+        assertEquals(url, "jdbc:redshift://test-endpoint:1234");
     }
 
     @Test
     public void test_getDefaultDriverClass() {
-        System.clearProperty("drivers.oracle.realDriverClass");
-        AWSSecretsManagerOracleDriver sut2 = new AWSSecretsManagerOracleDriver(cache);
+        System.clearProperty("drivers.redshift.realDriverClass");
+        AWSSecretsManagerRedshiftDriver sut2 = new AWSSecretsManagerRedshiftDriver(cache);
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Add Redshift driver to the JDBC driver.

Additional changes:
- Added the default GH gitignore for Maven
- Added small build workflow to get a build badge on the repo (does `mvn package`)
- Had to update some dependencies for the build to pass on newer versions of Maven.

Tested against a Redshift cluster, works.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
