### PR TITLE
Add override for default region.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+**.DS_Store
+.idea
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 jacoco.exec

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ drivers.vpcEndpointUrl= #The endpoint URL
 drivers.vpcEndpointRegion= #The endpoint region
 ```
 Both options must be set in order for this option to take effect.
+
 2) Override the region by setting the 'AWS_SECRET_JDBC_REGION' environment variable to the preferred region.
 
 3) Override the region via the secretsmanager.properties file.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,19 @@ The secret being used should be in the JSON format we use for our rotation lambd
 	...
 }
 ```
+### Overriding Default Regions
+
+The default region provider chain is used if no adjustments are made. In order to override this default, use one of the following options listed below.
+
+1) Set a PrivateLink DNS endpoint URL and region in the secretsmanager.properties file.
+```text
+drivers.vpcEndpointUrl= #The endpoint URL
+drivers.vpcEndpointRegion= #The endpoint region
+```
+Both options must be set in order for this option to take effect.
+2) Override the region by setting the 'AWS_SECRET_JDBC_REGION' environment variable to the preferred region.
+
+3) Override the region via the secretsmanager.properties file.
+```text
+drivers.region= #The region to use.
+```

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     <aws-secretsmanager-cache.version>1.0.2</aws-secretsmanager-cache.version>
     <lombok.version>1.18.24</lombok.version>
     <jackson.version>2.13.2.2</jackson.version>
-    <junit.version>4.13.2</junit.version>
-    <mockito.version>3.3.3</mockito.version>
-    <powermock.version>2.0.9</powermock.version>
+    <junit.version>4.13.1</junit.version>
+    <mockito.version>1.10.19</mockito.version>
+    <powermock.version>1.7.0</powermock.version>
     <compiler.plugin.version>3.2</compiler.plugin.version>
     <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
@@ -107,7 +107,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-all</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
@@ -121,7 +121,7 @@
 
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
+      <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <artifactId>aws-secretsmanager-jdbc</artifactId>
   <packaging>jar</packaging>
   <name>AWS Secrets Manager SQL Connection Library</name>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <description>The AWS Secrets Manager SQL Connection Library for Java enables Java developers to easily
     connect to SQL databases using secrets stored in AWS Secrets Manager.
   </description>

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     <aws-secretsmanager-cache.version>1.0.2</aws-secretsmanager-cache.version>
     <lombok.version>1.18.24</lombok.version>
     <jackson.version>2.13.2.2</jackson.version>
-    <junit.version>4.13.1</junit.version>
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.6</powermock.version>
+    <junit.version>4.13.2</junit.version>
+    <mockito.version>3.3.3</mockito.version>
+    <powermock.version>2.0.9</powermock.version>
     <compiler.plugin.version>3.2</compiler.plugin.version>
     <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
@@ -107,7 +107,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
@@ -121,7 +121,7 @@
 
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
@@ -3,7 +3,6 @@ package com.amazonaws.secretsmanager.util;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
 
 import static com.amazonaws.util.StringUtils.isNullOrEmpty;
 

--- a/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
@@ -3,7 +3,9 @@ package com.amazonaws.secretsmanager.util;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.util.StringUtils;
 
+import static com.amazonaws.util.StringUtils.isNullOrEmpty;
 
 /**
  * <p>
@@ -63,11 +65,11 @@ public class JDBCSecretCacheBuilderProvider {
 
 
         //Apply settings to our builder configuration.
-        if (vpcEndpointUrl != null && !vpcEndpointUrl.isEmpty() && vpcEndpointRegion != null && !vpcEndpointRegion.isEmpty()) {
+        if ( !isNullOrEmpty(vpcEndpointUrl) && !isNullOrEmpty(vpcEndpointRegion) ) {
             builder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(vpcEndpointUrl, vpcEndpointRegion));
-        } else if ( envRegion != null && !envRegion.isEmpty() ) {
+        } else if ( !isNullOrEmpty(envRegion) ) {
             builder.withRegion(envRegion);
-        } else if ( configRegion != null && !configRegion.isEmpty() ) {
+        } else if ( !isNullOrEmpty(configRegion) ) {
             builder.withRegion(configRegion);
         }
 

--- a/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
@@ -1,0 +1,76 @@
+package com.amazonaws.secretsmanager.util;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+
+
+/**
+ * <p>
+ *  A class for providing JDBC driver the secrets cache builder.
+ *
+ * Checks the config file and environment variables for overrides to the default
+ * region and applies those changes to the provided secret cache builder.
+ * </p>
+ */
+public class JDBCSecretCacheBuilderProvider {
+
+    /**
+     * Configuration property to override PrivateLink DNS URL for Secrets Manager
+     */
+    static final String PROPERTY_VPC_ENDPOINT_URL = "vpcEndpointUrl";
+
+    static final String PROPERTY_VPC_ENDPOINT_REGION = "vpcEndpointRegion";
+
+    /**
+     * Configuration properties to override the default region
+     */
+    static final String PROPERTY_REGION = "region";
+
+    static final String REGION_ENVIRONMENT_VARIABLE = "AWS_SECRET_JDBC_REGION";
+
+
+    private static Config Config;
+
+
+    public JDBCSecretCacheBuilderProvider() {
+        this(Config.loadMainConfig());
+    }
+
+    public JDBCSecretCacheBuilderProvider(Config config) {
+        Config = config;
+    }
+
+    /**
+     * Provides the secrets cache builder.
+     *
+     * 1) If a PrivateLink DNS endpoint URL and region are given in the Config, then they are used to configure the endpoint.
+     * 2) The AWS_SECRET_JDBC_REGION environment variable is checked. If set, it is used to configure the region.
+     * 3) The region variable file is checked in the provided Config and, if set, used to configure the region.
+     * 4) Finally, if none of these are not found, the default region provider chain is used.
+     *
+     * @return the built secret cache.
+     */
+    public AWSSecretsManagerClientBuilder build() {
+
+        AWSSecretsManagerClientBuilder builder = AWSSecretsManagerClientBuilder.standard();
+
+        //Retrieve data from information sources.
+        String vpcEndpointUrl = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL, null);
+        String vpcEndpointRegion = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION, null);
+        String envRegion = System.getenv(REGION_ENVIRONMENT_VARIABLE);
+        String configRegion = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_REGION, null);
+
+
+        //Apply settings to our builder configuration.
+        if (vpcEndpointUrl != null && !vpcEndpointUrl.isEmpty() && vpcEndpointRegion != null && !vpcEndpointRegion.isEmpty()) {
+            builder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(vpcEndpointUrl, vpcEndpointRegion));
+        } else if ( envRegion != null && !envRegion.isEmpty() ) {
+            builder.withRegion(envRegion);
+        } else if ( configRegion != null && !configRegion.isEmpty() ) {
+            builder.withRegion(configRegion);
+        }
+
+        return builder;
+    }
+}

--- a/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
@@ -30,7 +30,7 @@ public class JDBCSecretCacheBuilderProvider {
     static final String REGION_ENVIRONMENT_VARIABLE = "AWS_SECRET_JDBC_REGION";
 
 
-    private static Config Config;
+    private Config configFile;
 
 
     public JDBCSecretCacheBuilderProvider() {
@@ -38,7 +38,7 @@ public class JDBCSecretCacheBuilderProvider {
     }
 
     public JDBCSecretCacheBuilderProvider(Config config) {
-        Config = config;
+        configFile = config;
     }
 
     /**
@@ -56,10 +56,10 @@ public class JDBCSecretCacheBuilderProvider {
         AWSSecretsManagerClientBuilder builder = AWSSecretsManagerClientBuilder.standard();
 
         //Retrieve data from information sources.
-        String vpcEndpointUrl = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL, null);
-        String vpcEndpointRegion = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION, null);
+        String vpcEndpointUrl = configFile.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL, null);
+        String vpcEndpointRegion = configFile.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION, null);
         String envRegion = System.getenv(REGION_ENVIRONMENT_VARIABLE);
-        String configRegion = Config.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_REGION, null);
+        String configRegion = configFile.getStringPropertyWithDefault(AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_REGION, null);
 
 
         //Apply settings to our builder configuration.

--- a/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
@@ -4,20 +4,21 @@ package com.amazonaws.secretsmanager.util;
 import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;
+
+import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 
 import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.*;
 
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({Config.class, System.class, JDBCSecretCacheBuilderProvider.class})
 public class JDBCSecretCacheBuilderProviderTest {
 

--- a/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
@@ -1,0 +1,213 @@
+package com.amazonaws.secretsmanager.util;
+
+
+import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import org.powermock.api.mockito.PowerMockito;
+
+
+import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.*;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Config.class, System.class, JDBCSecretCacheBuilderProvider.class})
+public class JDBCSecretCacheBuilderProviderTest {
+
+    /**
+     * SetRegion Tests.
+     */
+    @Test
+    public void test_setRegion_configFileProperty() {
+        Config configProvider = PowerMockito.mock(Config.class);
+        String regionName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+ JDBCSecretCacheBuilderProvider.PROPERTY_REGION;
+        when(configProvider.getStringPropertyWithDefault(regionName, null)).thenReturn("asdf");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertEquals("asdf", builder.getRegion());
+    }
+
+
+    @Test
+    public void test_setRegion_environmentVariable() {
+        Config configProvider = PowerMockito.mock(Config.class);
+        PowerMockito.mockStatic(System.class);
+
+        String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
+        when(System.getenv(environmentRegionName)).thenReturn("asdf");
+        assertEquals("asdf", System.getenv(environmentRegionName));
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+        assertEquals("asdf", builder.getRegion());
+    }
+
+
+    @Test
+    public void test_setRegion_vpcEndpoint() {
+        Config configProvider = PowerMockito.mock(Config.class);
+        String vpcEndpointUrlName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL;
+        String vpcEndpointRegion = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION;
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointUrlName, null)).thenReturn("asdf");
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointRegion, null)).thenReturn("qwerty");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertEquals("asdf", builder.getEndpoint().getServiceEndpoint());
+        assertEquals("qwerty", builder.getEndpoint().getSigningRegion());
+    }
+
+
+    @Test
+    public void test_setRegion_defaultsToNull() {
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider().build();
+        assertNull(builder.getRegion());
+    }
+
+    /**
+     * SetRegion priority tests.
+     */
+
+    @Test
+    public void test_regionSelectionOrder_prefersVpcEndpointOverEverything() {
+        Config configProvider = PowerMockito.mock(Config.class);
+        PowerMockito.mockStatic(System.class);
+
+        //Arrange so all properties return something valid.
+        String regionName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+ JDBCSecretCacheBuilderProvider.PROPERTY_REGION;
+        String vpcEndpointUrlName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL;
+        String vpcEndpointRegion = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION;
+        String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
+
+        //Arrange the return values when the properties are requested.
+        when(System.getenv(environmentRegionName)).thenReturn("0");
+        when(configProvider.getStringPropertyWithDefault(regionName, null)).thenReturn("1");
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointUrlName, null)).thenReturn("2");
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointRegion, null)).thenReturn("3");
+
+        //Act: Build our clientbuilder.
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        //Assert: Make sure the endpoint was configured properly.
+        assertEquals("3", builder.getEndpoint().getSigningRegion());
+        assertEquals("2", builder.getEndpoint().getServiceEndpoint());
+        assertNotEquals("1", builder.getRegion());
+        assertNotEquals("0", builder.getRegion());
+    }
+
+
+
+    @Test
+    public void test_regionSelectionOrder_prefersEnvironmentVarOverConfig() {
+        Config configProvider = PowerMockito.mock(Config.class);
+        PowerMockito.mockStatic(System.class);
+
+        String regionName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+ JDBCSecretCacheBuilderProvider.PROPERTY_REGION;
+        String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
+
+        when(System.getenv(environmentRegionName)).thenReturn("0");
+        when(configProvider.getStringPropertyWithDefault(regionName, null)).thenReturn("1");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNotEquals("1", builder.getRegion());
+        assertEquals("0", builder.getRegion());
+    }
+
+
+    /**
+     * Variables must be correctly set
+     */
+    @Test
+    public void test_settingValidation_emptyConfigPropertyIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        String regionName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+ JDBCSecretCacheBuilderProvider.PROPERTY_REGION;
+        when(configProvider.getStringPropertyWithDefault(regionName, null)).thenReturn("");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getRegion());
+    }
+
+    @Test
+    public void test_settingValidation_nullConfigPropertyIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        String regionName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+ JDBCSecretCacheBuilderProvider.PROPERTY_REGION;
+        when(configProvider.getStringPropertyWithDefault(regionName, null)).thenReturn("");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getRegion());
+    }
+
+    @Test
+    public void test_settingValidation_emptyEnvironmentVariableIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        PowerMockito.mockStatic(System.class);
+
+        String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
+        when(System.getenv(environmentRegionName)).thenReturn("");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getRegion());
+    }
+
+
+    @Test
+    public void test_settingValidation_nullEnvironmentVariableIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        PowerMockito.mockStatic(System.class);
+
+        String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
+        when(System.getenv(environmentRegionName)).thenReturn(null);
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getRegion());
+    }
+
+
+
+
+    @Test
+    public void test_settingValidation_emptyVpcIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        String vpcEndpointUrlName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL;
+        String vpcEndpointRegion = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION;
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointUrlName, null)).thenReturn("");
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointRegion, null)).thenReturn("");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getEndpoint());
+    }
+
+
+    @Test
+    public void test_settingValidation_nullVpcIgnored() {
+
+        Config configProvider = PowerMockito.mock(Config.class);
+        String vpcEndpointUrlName = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_URL;
+        String vpcEndpointRegion = AWSSecretsManagerDriver.PROPERTY_PREFIX+"."+PROPERTY_VPC_ENDPOINT_REGION;
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointUrlName, null)).thenReturn("");
+        when(configProvider.getStringPropertyWithDefault(vpcEndpointRegion, null)).thenReturn("");
+
+        AWSSecretsManagerClientBuilder builder = new JDBCSecretCacheBuilderProvider(configProvider).build();
+
+        assertNull(builder.getEndpoint());
+    }
+
+}


### PR DESCRIPTION
Resolves Issue #27 

This change allows overriding of the default region by either adding an environment variable or by a setting in the secretsmanager.properties file. Some small refactoring of where we set the PrivateLink DNS endpoint configuration was done in the process. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
