### PR TITLE
unwrap exception cause to find nested authentication error

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
@@ -106,11 +106,20 @@ public final class AWSSecretsManagerMariaDBDriver extends AWSSecretsManagerDrive
 
     @Override
     public boolean isExceptionDueToAuthenticationError(Exception e) {
-        if (e instanceof SQLException) {
-            SQLException sqle = (SQLException) e;
-            int errorCode = sqle.getErrorCode();
-            return errorCode == ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE;
-        }
+        Throwable t = e;
+        do {
+            if (t instanceof SQLException) {
+                SQLException sqle = (SQLException) t;
+                int errorCode = sqle.getErrorCode();
+                if (errorCode == ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) {
+                    return true;
+                } else {
+                    t = t.getCause();
+                }
+            } else {
+                t = t.getCause();
+            }
+        } while (t != null);
         return false;
     }
 

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -102,5 +102,21 @@ public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
         AWSSecretsManagerMariaDBDriver sut2 = new AWSSecretsManagerMariaDBDriver(cache);
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctWrappedException() {
+        SQLException e = new SQLException("", "", 1045);
+        SQLException wrapper = new SQLException("", "", 0, e);
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(wrapper));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongWrappedSQLException() {
+        SQLException e = new SQLException("", "", 1046);
+        SQLException wrapper = new SQLException("", "", 0, e);
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(wrapper));
+    }
 }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-secretsmanager-jdbc/issues/113

*Description of changes:*
While attempting to connect with database, sometimes the actual exception containing vendor code (1045) that denotes authentication failure is nested in outer exceptions. An example of such case is shown below:

```
caused by java.sql.SQLTransientConnectionException: ServiceDB - Connection is not available, request timed out after 5000ms.
…g.jooq.impl.ProviderEnabledConnection.prepareStatement(ProviderEnabledConnection.java:109)
…g.jooq.impl.SettingsEnabledConnection.prepareStatement(SettingsEnabledConnection.java:73)
              org.jooq.impl.AbstractResultQuery.prepare(AbstractResultQuery.java:274)
                    org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:338)
                org.jooq.impl.AbstractResultQuery.fetch(AbstractResultQuery.java:354)
            org.jooq.impl.AbstractResultQuery.fetchInto(AbstractResultQuery.java:1550)
                     org.jooq.impl.SelectImpl.fetchInto(SelectImpl.java:3746)
jdk.internal.reflect.GeneratedMethodAccessor219.invoke(Unknown Source)
         graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:279)
…aphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:210)
       graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:60)
           graphql.execution.Execution.executeOperation(Execution.java:159)
                    graphql.execution.Execution.execute(Execution.java:105)
                                graphql.GraphQL.execute(GraphQL.java:613)
                graphql.GraphQL.parseValidateAndExecute(GraphQL.java:538)
                           graphql.GraphQL.executeAsync(GraphQL.java:502)
jdk.internal.reflect.GeneratedMethodAccessor218.invoke(Unknown Source)
caused by java.sql.SQLNonTransientConnectionException: Communications link failure with primary. No active connection found for master. 
….failover.AbstractMastersListener.throwFailoverMessage(AbstractMastersListener.java:559)
…er.impl.MastersReplicasListener.checkInitialConnection(MastersReplicasListener.java:350)
…over.impl.MastersReplicasListener.initializeConnection(MastersReplicasListener.java:179)
…rg.mariadb.jdbc.internal.failover.FailoverProxy.<init>(FailoverProxy.java:120)
     org.mariadb.jdbc.internal.util.Utils.retrieveProxy(Utils.java:608)
       org.mariadb.jdbc.MariaDbConnection.newConnection(MariaDbConnection.java:150)
                        org.mariadb.jdbc.Driver.connect(Driver.java:89)
caused by java.sql.SQLNonTransientConnectionException: Could not connect to HostAddress{host='xxxxxx.us-west-2.rds.amazonaws.com', port=3306}. (conn=538090) Access denied for user 'xxxxxx'@'xxxxxx' (using password: YES)Current charset is UTF-8. If password has been set using other charset, consider using option 'passwordCharacterEncoding'
…ernal.util.exceptions.ExceptionFactory.createException(ExceptionFactory.java:73)
….jdbc.internal.util.exceptions.ExceptionFactory.create(ExceptionFactory.java:185)
…jdbc.internal.protocol.AbstractConnectProtocol.connect(AbstractConnectProtocol.java:500)
org.mariadb.jdbc.internal.protocol.AuroraProtocol.loop(AuroraProtocol.java:170)
…failover.impl.AuroraListener.reconnectFailedConnection(AuroraListener.java:213)
…over.impl.MastersReplicasListener.initializeConnection(MastersReplicasListener.java:176)
…rg.mariadb.jdbc.internal.failover.FailoverProxy.<init>(FailoverProxy.java:120)
     org.mariadb.jdbc.internal.util.Utils.retrieveProxy(Utils.java:608)
       org.mariadb.jdbc.MariaDbConnection.newConnection(MariaDbConnection.java:150)
                        org.mariadb.jdbc.Driver.connect(Driver.java:89)
caused by java.sql.SQLInvalidAuthorizationSpecException: (conn=538090) Access denied for user 'xxxx'@'xxxx' (using password: YES)Current charset is UTF-8. If password has been set using other charset, consider using option 'passwordCharacterEncoding'
…ernal.util.exceptions.ExceptionFactory.createException(ExceptionFactory.java:66)
….jdbc.internal.util.exceptions.ExceptionFactory.create(ExceptionFactory.java:189)
…protocol.AbstractConnectProtocol.authenticationHandler(AbstractConnectProtocol.java:769)
…rnal.protocol.AbstractConnectProtocol.createConnection(AbstractConnectProtocol.java:555)
…jdbc.internal.protocol.AbstractConnectProtocol.connect(AbstractConnectProtocol.java:498)
org.mariadb.jdbc.internal.protocol.AuroraProtocol.loop(AuroraProtocol.java:170)
…failover.impl.AuroraListener.reconnectFailedConnection(AuroraListener.java:213)
…over.impl.MastersReplicasListener.initializeConnection(MastersReplicasListener.java:176)
…rg.mariadb.jdbc.internal.failover.FailoverProxy.<init>(FailoverProxy.java:120)
     org.mariadb.jdbc.internal.util.Utils.retrieveProxy(Utils.java:608)
       org.mariadb.jdbc.MariaDbConnection.newConnection(MariaDbConnection.java:150)
                        org.mariadb.jdbc.Driver.connect(Driver.java:89)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
