### PR TITLE
Added support for fetching H2 database secrets from Secret Manager

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerH2Driver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerH2Driver.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.secretsmanager.sql;
+
+import java.sql.SQLException;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.util.StringUtils;
+
+/**
+ * <p>
+ * Provides support for accessing H2 databases using credentials stored within AWS Secrets Manager.
+ * </p>
+ *
+ * <p>
+ * Configuration properties are specified using the "h2" subprefix (e.g drivers.h2.realDriverClass).
+ * </p>
+ */
+public final class AWSSecretsManagerH2Driver extends AWSSecretsManagerDriver {
+
+    /**
+     * The H2 error code for when a user logs in using an invalid password.
+     *
+     * See <a https://www.h2database.com/javadoc/org/h2/api/ErrorCode.html ">PostgreSQL documentation</a>.
+     */
+    public static final String 	WRONG_USER_OR_PASSWORD = "28000";
+    
+    /**
+     * Set to h2.
+     */
+    public static final String SUBPREFIX = "h2";
+
+    static {
+        AWSSecretsManagerDriver.register(new AWSSecretsManagerH2Driver());
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with default options.
+     */
+    public AWSSecretsManagerH2Driver() {
+        super();
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Uses the passed in SecretCache.
+     *
+     * @param cache                                             Secret cache to use to retrieve secrets
+     */
+    public AWSSecretsManagerH2Driver(SecretCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the passed in client builder.
+     *
+     * @param builder                                           Builder used to instantiate cache
+     */
+    public AWSSecretsManagerH2Driver(AWSSecretsManagerClientBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the provided AWS Secrets Manager client.
+     *
+     * @param client                                            AWS Secrets Manager client to instantiate cache
+     */
+    public AWSSecretsManagerH2Driver(AWSSecretsManager client) {
+        super(client);
+    }
+
+    /**
+     * Constructs the driver setting the properties from the properties file using system properties as defaults.
+     * Instantiates the secret cache with the provided cache configuration.
+     *
+     * @param cacheConfig                                       Cache configuration to instantiate cache
+     */
+    public AWSSecretsManagerH2Driver(SecretCacheConfiguration cacheConfig) {
+        super(cacheConfig);
+    }
+
+    @Override
+    public String getPropertySubprefix() {
+        return SUBPREFIX;
+    }
+
+    @Override
+    public boolean isExceptionDueToAuthenticationError(Exception e) {
+        if (e instanceof SQLException) {
+            SQLException sqle = (SQLException) e;
+            String sqlState = sqle.getSQLState();
+            return sqlState.equals(WRONG_USER_OR_PASSWORD);
+        }
+        return false;
+    }
+
+    @Override
+    public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
+        String url = "jdbc:h2:tcp://" + endpoint;
+        if (!StringUtils.isNullOrEmpty(port)) {
+            url += ":" + port;
+        }
+        if (!StringUtils.isNullOrEmpty(dbname)) {
+            url += "/" + dbname;
+        }
+        return url;
+    }
+
+    @Override
+    public String getDefaultDriverClass() {
+        return "org.h2.Driver";
+    }
+}

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerH2DriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerH2DriverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.secretsmanager.sql;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.Before;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.util.TestClass;
+
+/**
+ * Tests for the H2 Driver.
+ */
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerH2Driver")
+@PowerMockIgnore("jdk.internal.reflect.*")
+public class AWSSecretsManagerH2DriverTest extends TestClass {
+
+    private AWSSecretsManagerH2Driver sut;
+
+    @Mock
+    private SecretCache cache;
+
+    @Before
+    public void setup() {
+        System.setProperty("drivers.h2.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
+        MockitoAnnotations.initMocks(this);
+        try {
+            sut = new AWSSecretsManagerH2Driver(cache);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void test_getPropertySubprefix() {
+        assertEquals("h2", sut.getPropertySubprefix());
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_correctException() {
+        SQLException e = new SQLException("", "28000");
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
+        SQLException e = new SQLException("", "28001");
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsFalse_runtimeException() {
+        RuntimeException e = new RuntimeException("asdf");
+
+        assertFalse(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_constructUrl() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", "dev");
+        assertEquals(url, "jdbc:h2:tcp://test-endpoint:1234/dev");
+    }
+
+    @Test
+    public void test_constructUrlNullPort() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", null, "dev");
+        assertEquals(url, "jdbc:h2:tcp://test-endpoint/dev");
+    }
+
+    @Test
+    public void test_constructUrlNullDatabase() {
+        String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", null);
+        assertEquals(url, "jdbc:h2:tcp://test-endpoint:1234");
+    }
+
+    @Test
+    public void test_getDefaultDriverClass() {
+        System.clearProperty("drivers.h2.realDriverClass");
+        AWSSecretsManagerH2Driver sut2 = new AWSSecretsManagerH2Driver(cache);
+        assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
+    }
+}


### PR DESCRIPTION


*Enhancement:* Supporting H2 database 

*Description of changes:*
Added new Driver AWSSecretsManagerH2Driver which wraps around org.h2.Driver to fetch database password from AWS secrets manager

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
