### PR TITLE
Ensure wrapped driver exists on classpath at time of registration

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -135,6 +135,8 @@ public abstract class AWSSecretsManagerDriver implements Driver {
 
         setProperties();
         AWSSecretsManagerDriver.register(this);
+
+        getWrappedDriver();
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -44,7 +44,10 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
     public static final String SUBPREFIX = "postgresql";
 
     static {
-        AWSSecretsManagerDriver.register(new AWSSecretsManagerPostgreSQLDriver());
+        AWSSecretsManagerDriver driver = new AWSSecretsManagerPostgreSQLDriver();
+        AWSSecretsManagerDriver.register(driver);
+        // Prime the class loader
+        driver.getWrappedDriver();
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -44,10 +44,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
     public static final String SUBPREFIX = "postgresql";
 
     static {
-        AWSSecretsManagerDriver driver = new AWSSecretsManagerPostgreSQLDriver();
-        AWSSecretsManagerDriver.register(driver);
-        // Prime the class loader
-        driver.getWrappedDriver();
+        AWSSecretsManagerDriver.register(new AWSSecretsManagerPostgreSQLDriver());
     }
 
     /**


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Initialization and registration of the AWS driver can happen successfully while later JDBC actions failed due to the wrapped driver's not existing.  For example, if "org.postgresql.Driver" does not exist on the classpath this will be discovered later than it needs to be at runtime.  Additionally, loading the drivers during the registration process facilitates detection of required classes by frameworks such as quarkus when building optimized builds.

To ensure required classes are loaded during registration, I added a called to "getWrappedDriver()" to the end of the AWSSecretsManagerDriver(SecretCache cache) constructor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
