### PR TITLE
Always append slash after Postgres db endpoint

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -116,8 +116,11 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
         if (!StringUtils.isNullOrEmpty(port)) {
             url += ":" + port;
         }
+
+        url += "/";
+
         if (!StringUtils.isNullOrEmpty(dbname)) {
-            url += "/" + dbname;
+            url += dbname;
         }
         return url;
     }

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -93,7 +93,7 @@ public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
     @Test
     public void test_constructUrlNullDatabase() {
         String url = sut.constructUrlFromEndpointPortDatabase("test-endpoint", "1234", null);
-        assertEquals(url, "jdbc:postgresql://test-endpoint:1234");
+        assertEquals(url, "jdbc:postgresql://test-endpoint:1234/");
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* Fixes #208

*Description of changes:*

[Postgres docs](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database) on the matter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
