### PR TITLE
V2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,9 @@ name: Java Build
 
 on: [push, pull_request]
 
+env:
+  AWS_DEFAULT_REGION: us-west-2
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,4 +19,4 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master", "v2"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "v2"]
   schedule:
     - cron: '38 2 * * 1'
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ jacoco.exec
 # Eclipse m2e generated files
 # Eclipse Core
 .project
+.settings
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The secret being used should be in the JSON format we use for our rotation lambd
 
 ## Credentials
 
-This library uses the [Default Credential Provider Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). The following options exist to override some of the defaults:
+This library uses the [Default Credential Provider Chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html). The following options exist to override some of the defaults:
 
 1) Set a PrivateLink DNS endpoint URL and a region in the secretsmanager.properties file:
 ```text

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS Secrets Manager JDBC Library
 
 [![Java Build](https://github.com/aws/aws-secretsmanager-jdbc/actions/workflows/CI.yml/badge.svg?event=push)](https://github.com/aws/aws-secretsmanager-jdbc/actions/workflows/CI.yml)
-[![Coverage](https://codecov.io/gh/aws/aws-secretsmanager-jdbc/branch/master/graph/badge.svg?token=hCl7eBaSwn)](https://codecov.io/gh/aws/aws-secretsmanager-jdbc)
+[![Coverage](https://codecov.io/gh/aws/aws-secretsmanager-jdbc/branch/v2/graph/badge.svg?token=hCl7eBaSwn)](https://codecov.io/gh/aws/aws-secretsmanager-jdbc)
 
 The **AWS Secrets Manager JDBC Library** enables Java developers to easily connect to SQL databases using secrets stored in AWS Secrets Manager.
 
@@ -25,7 +25,7 @@ The recommended way to use the SQL Connection Library is to consume it from Mave
 <dependency>
     <groupId>com.amazonaws.secretsmanager</groupId>
     <artifactId>aws-secretsmanager-jdbc</artifactId>
-    <version>1.0.12</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,25 +16,13 @@
   <artifactId>aws-secretsmanager-jdbc</artifactId>
   <packaging>jar</packaging>
   <name>AWS Secrets Manager SQL Connection Library</name>
-  <version>1.0.12</version>
+  <version>2.0.0</version>
   <description>The AWS Secrets Manager SQL Connection Library for Java enables Java developers to easily
     connect to SQL databases using secrets stored in AWS Secrets Manager.
   </description>
   <url>https://aws.amazon.com/secrets-manager</url>
 
   <properties>
-    <aws-java-sdk.version>1.12.252</aws-java-sdk.version>
-    <aws-secretsmanager-cache.version>1.0.2</aws-secretsmanager-cache.version>
-    <lombok.version>1.18.24</lombok.version>
-    <jackson.version>2.14.1</jackson.version>
-    <junit.version>4.13.2</junit.version>
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.7.0</powermock.version>
-    <compiler.plugin.version>3.10.1</compiler.plugin.version>
-    <javadoc.plugin.version>3.4.0</javadoc.plugin.version>
-    <source.plugin.version>3.2.1</source.plugin.version>
-    <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
-    <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -76,61 +64,67 @@
     <dependency>
       <groupId>com.amazonaws.secretsmanager</groupId>
       <artifactId>aws-secretsmanager-caching-java</artifactId>
-      <version>${aws-secretsmanager-cache.version}</version>
+      <version>2.0.0</version>
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-secretsmanager</artifactId>
-      <version>${aws-java-sdk.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>secretsmanager</artifactId>
+      <version>2.20.93</version>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
+      <version>1.18.28</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>2.15.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.7.3</version>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito.version}</version>
+      <artifactId>mockito-inline</artifactId>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
+      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.9</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>org.jacoco.agent</artifactId>
-      <classifier>runtime</classifier>
-      <version>0.8.8</version>
     </dependency>
   </dependencies>
 
@@ -139,17 +133,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.plugin.version}</version>
+        <version>3.11.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>${source.plugin.version}</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -162,7 +156,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -175,10 +169,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${checkstyle.plugin.version}</version>
+        <version>3.3.0</version>
         <configuration>
           <configLocation>${basedir}/config/checkstyle/checkstyle.xml</configLocation>
-          <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <linkXRef>false</linkXRef>
@@ -197,7 +190,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${spotbugs.plugin.version}</version>
+        <version>4.7.3.5</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>
@@ -216,44 +209,21 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
-            <id>default-instrument</id>
             <goals>
-              <goal>instrument</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-restore-instrumented-classes</id>
-            <goals>
-              <goal>restore-instrumented-classes</goal>
+              <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
+            <phase>test</phase>
             <goals>
               <goal>report</goal>
             </goals>
           </execution>
-          <execution>
-            <id>default-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
-        <configuration>
-          <systemPropertyVariables>
-            <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-          </systemPropertyVariables>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -266,7 +236,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <javadoc.plugin.version>3.4.0</javadoc.plugin.version>
     <source.plugin.version>3.2.1</source.plugin.version>
     <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
-    <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+    <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -125,6 +125,7 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>org.jacoco.agent</artifactId>
@@ -194,9 +195,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs.plugin.version}</version>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs.plugin.version}</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -342,7 +342,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
                 JsonNode jsonObject = mapper.readTree(secretString);
                 updatedInfo.setProperty("user", jsonObject.get("username").asText());
                 updatedInfo.setProperty("password", jsonObject.get("password").asText());
-            } catch (IOException | NullPointerException e) {
+            } catch (IOException e) {
                 // Most likely to occur in the event that the data is not JSON.
                 // Or the secret's username and/or password fields have been
                 // removed entirely. Either scenario is most often a user error.
@@ -391,7 +391,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
                 JsonNode dbnameNode = jsonObject.get("dbname");
                 String dbname = dbnameNode == null ? null : dbnameNode.asText();
                 unwrappedUrl = constructUrlFromEndpointPortDatabase(endpoint, port, dbname);
-            } catch (IOException | NullPointerException e) {
+            } catch (IOException e) {
                 // Most likely to occur in the event that the data is not JSON.
                 // Or the secret has been modified and is no longer valid.
                 // Either scenario is most often a user error.

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -12,16 +12,6 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import com.amazonaws.secretsmanager.util.Config;
-import com.amazonaws.secretsmanager.caching.SecretCache;
-import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Driver;
@@ -32,6 +22,19 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.logging.Logger;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
+import com.amazonaws.secretsmanager.util.Config;
+import com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -130,6 +133,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      *
      * @param cache                                             Secret cache to use to retrieve secrets
      */
+    @SuppressFBWarnings("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
     protected AWSSecretsManagerDriver(SecretCache cache) {
         this.secretCache = cache;
 
@@ -143,7 +147,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    protected AWSSecretsManagerDriver(AWSSecretsManagerClientBuilder builder) {
+    protected AWSSecretsManagerDriver(SecretsManagerClientBuilder builder) {
         this(new SecretCache(builder));
     }
 
@@ -153,7 +157,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    protected AWSSecretsManagerDriver(AWSSecretsManager client) {
+    protected AWSSecretsManagerDriver(SecretsManagerClient client) {
         this(new SecretCache(client));
     }
 
@@ -380,7 +384,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
         } else { // Else, assume this is a secret ID and try to retrieve it
             try {
                 String secretString = secretCache.getSecretString(url);
-                if (StringUtils.isNullOrEmpty(secretString)) {
+                if (StringUtils.isBlank(secretString)) {
                     throw new IllegalArgumentException("URL " + url + " is not a valid URL starting with scheme " +
                             SCHEME + " or a valid retrievable secret ID ");
                 }
@@ -437,4 +441,3 @@ public abstract class AWSSecretsManagerDriver implements Driver {
         return getWrappedDriver().jdbcCompliant();
     }
 }
-

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriver.java
@@ -16,9 +16,10 @@ import java.sql.SQLException;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -74,7 +75,7 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerMSSQLServerDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerMSSQLServerDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -84,7 +85,7 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerMSSQLServerDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerMSSQLServerDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -116,10 +117,10 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:sqlserver://" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += ";databaseName=" + dbname + ";";
         }
         return url;
@@ -130,4 +131,3 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
         return "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     }
 }
-

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriver.java
@@ -15,9 +15,10 @@ package com.amazonaws.secretsmanager.sql;
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
 import com.amazonaws.secretsmanager.util.SQLExceptionUtils;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -74,7 +75,7 @@ public final class AWSSecretsManagerMariaDBDriver extends AWSSecretsManagerDrive
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerMariaDBDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerMariaDBDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -84,7 +85,7 @@ public final class AWSSecretsManagerMariaDBDriver extends AWSSecretsManagerDrive
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerMariaDBDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerMariaDBDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -111,10 +112,10 @@ public final class AWSSecretsManagerMariaDBDriver extends AWSSecretsManagerDrive
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:mariadb://" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += "/" + dbname;
         }
         return url;

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriver.java
@@ -15,9 +15,10 @@ package com.amazonaws.secretsmanager.sql;
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
 import com.amazonaws.secretsmanager.util.SQLExceptionUtils;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -74,7 +75,7 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerMySQLDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerMySQLDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -84,7 +85,7 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerMySQLDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerMySQLDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -111,10 +112,10 @@ public final class AWSSecretsManagerMySQLDriver extends AWSSecretsManagerDriver 
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:mysql://" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += "/" + dbname;
         }
         return url;

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriver.java
@@ -16,9 +16,10 @@ import java.sql.SQLException;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -89,7 +90,7 @@ public final class AWSSecretsManagerOracleDriver extends AWSSecretsManagerDriver
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerOracleDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerOracleDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -99,7 +100,7 @@ public final class AWSSecretsManagerOracleDriver extends AWSSecretsManagerDriver
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerOracleDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerOracleDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -133,10 +134,10 @@ public final class AWSSecretsManagerOracleDriver extends AWSSecretsManagerDriver
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:oracle:thin:@//" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += "/" + dbname;
         }
         return url;
@@ -147,4 +148,3 @@ public final class AWSSecretsManagerOracleDriver extends AWSSecretsManagerDriver
         return "oracle.jdbc.OracleDriver";
     }
 }
-

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -16,9 +16,10 @@ import java.sql.SQLException;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -71,7 +72,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerPostgreSQLDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerPostgreSQLDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -81,7 +82,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerPostgreSQLDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerPostgreSQLDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -113,15 +114,16 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:postgresql://" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
 
         url += "/";
 
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += dbname;
         }
+
         return url;
     }
 
@@ -130,4 +132,3 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
         return "org.postgresql.Driver";
     }
 }
-

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
@@ -16,9 +16,10 @@ import java.sql.SQLException;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * <p>
@@ -74,7 +75,7 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
      *
      * @param builder Builder used to instantiate cache
      */
-    public AWSSecretsManagerRedshiftDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerRedshiftDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -85,7 +86,7 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
      *
      * @param client AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerRedshiftDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerRedshiftDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -118,10 +119,10 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
     @Override
     public String constructUrlFromEndpointPortDatabase(String endpoint, String port, String dbname) {
         String url = "jdbc:redshift://" + endpoint;
-        if (!StringUtils.isNullOrEmpty(port)) {
+        if (StringUtils.isNotBlank(port)) {
             url += ":" + port;
         }
-        if (!StringUtils.isNullOrEmpty(dbname)) {
+        if (StringUtils.isNotBlank(dbname)) {
             url += "/" + dbname;
         }
         return url;

--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -12,9 +12,8 @@
  */
 package com.amazonaws.secretsmanager.util;
 
-import java.io.InputStream;
 import java.io.IOException;
-
+import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -138,6 +137,7 @@ public final class Config {
      *
      * @return Config                                           Configuration properties for the subprefix
      */
+    @SuppressWarnings("unchecked")
     public Config getSubconfig(String subprefix) {
         Enumeration<String> propertyNames = (Enumeration<String>) config.propertyNames();
         Properties subconfig = null;
@@ -257,7 +257,7 @@ public final class Config {
      *
      * @throws PropertyException                                If the class name does not exist in this class loader.
      */
-    public Class getClassPropertyWithDefault(String propertyName, Class defaultValue) {
+    public Class<?> getClassPropertyWithDefault(String propertyName, Class<?> defaultValue) {
         String propertyValue = config.getProperty(propertyName);
         if (propertyValue == null) {
             return defaultValue;
@@ -348,7 +348,7 @@ public final class Config {
      * @throws PropertyException                                If the class name does not exist in this class loader.
      * @throws NoSuchElementException                           If the property is not set.
      */
-    public Class getRequiredClassProperty(String propertyName) {
+    public Class<?> getRequiredClassProperty(String propertyName) {
         throwIfPropertyIsNotSet(propertyName);
         return getClassPropertyWithDefault(propertyName, null);
     }

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -12,14 +12,18 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
-
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -30,13 +34,13 @@ import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
 import com.amazonaws.secretsmanager.util.TestClass;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
 /**
  * Tests for AWSSecretsManagerDriver. Uses a config file in the resources folder just to make sure it can read from
@@ -127,13 +131,13 @@ public class AWSSecretsManagerDriverTest extends TestClass {
     @Test
     public void test_init_constructor_null_params() {
         try {
-            new AWSSecretsManagerDummyDriver((AWSSecretsManagerClientBuilder)null);
+            new AWSSecretsManagerDummyDriver((SecretsManagerClientBuilder) null);
         } catch (Exception e) {}
         try {
-            new AWSSecretsManagerDummyDriver((SecretCacheConfiguration)null);
+            new AWSSecretsManagerDummyDriver((SecretCacheConfiguration) null);
         } catch (Exception e) {}
         try {
-            new AWSSecretsManagerDummyDriver((AWSSecretsManager)null);
+            new AWSSecretsManagerDummyDriver((SecretsManagerClient) null);
         } catch (Exception e) {}
     }
 
@@ -343,7 +347,7 @@ public class AWSSecretsManagerDriverTest extends TestClass {
     public void test_getPropertyInfo_propagatesToRealDriver() {
         String param1 = "jdbc-secretsmanager:expectedUrl";
         Properties param2 = new Properties();
-        assertNotThrows(() -> assertEquals(null, sut.getPropertyInfo(param1, param2)));
+        assertNotThrows(() -> Assert.assertNull(sut.getPropertyInfo(param1, param2)));
         assertEquals(1, DummyDriver.getPropertyInfoCallCount);
         String param1Expected = "jdbc:expectedUrl";
         assertEquals(param1Expected, DummyDriver.getPropertyInfoParam1);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDummyDriver.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDummyDriver.java
@@ -14,8 +14,9 @@ package com.amazonaws.secretsmanager.sql;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
 /**
  * Dummy database driver wrapper.
@@ -46,7 +47,7 @@ public class AWSSecretsManagerDummyDriver extends AWSSecretsManagerDriver {
      *
      * @param builder                                           Builder used to instantiate cache
      */
-    public AWSSecretsManagerDummyDriver(AWSSecretsManagerClientBuilder builder) {
+    public AWSSecretsManagerDummyDriver(SecretsManagerClientBuilder builder) {
         super(builder);
     }
 
@@ -56,7 +57,7 @@ public class AWSSecretsManagerDummyDriver extends AWSSecretsManagerDriver {
      *
      * @param client                                            AWS Secrets Manager client to instantiate cache
      */
-    public AWSSecretsManagerDummyDriver(AWSSecretsManager client) {
+    public AWSSecretsManagerDummyDriver(SecretsManagerClient client) {
         super(client);
     }
 
@@ -76,6 +77,7 @@ public class AWSSecretsManagerDummyDriver extends AWSSecretsManagerDriver {
     }
 
     public boolean exceptionIsDueToAuth;
+
     @Override
     public boolean isExceptionDueToAuthenticationError(Exception e) {
         return exceptionIsDueToAuth;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -103,4 +105,3 @@ public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -103,4 +105,3 @@ public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -103,4 +105,3 @@ public class AWSSecretsManagerMySQLDriverTest extends TestClass {
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -108,4 +110,3 @@ public class AWSSecretsManagerOracleDriverTest extends TestClass {
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -103,4 +105,3 @@ public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
         assertEquals(getFieldFrom(sut2, "realDriverClass"), sut2.getDefaultDriverClass());
     }
 }
-

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
@@ -12,10 +12,13 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
-
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Before;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;

--- a/src/test/java/com/amazonaws/secretsmanager/util/ConfigTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/ConfigTest.java
@@ -12,10 +12,11 @@
  */
 package com.amazonaws.secretsmanager.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.util.NoSuchElementException;
 import java.util.Properties;
-
-import static org.junit.Assert.*;
 
 import org.junit.Test;
 

--- a/src/test/java/com/amazonaws/secretsmanager/util/SQLExceptionUtilsTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/SQLExceptionUtilsTest.java
@@ -1,21 +1,18 @@
 package com.amazonaws.secretsmanager.util;
 
-import org.junit.Test;
-
-import java.sql.SQLException;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.sql.SQLException;
+
+import org.junit.Test;
 
 public class SQLExceptionUtilsTest {
-
 
     @Test
     public void test_unwrapAndCheckForCode_nullReturnsFalse() {
         assertFalse(SQLExceptionUtils.unwrapAndCheckForCode(null, 1045));
     }
-
 
     @Test
     public void test_unwrapAndCheckForCode_wrappedException_returnsTrue() {
@@ -32,7 +29,6 @@ public class SQLExceptionUtilsTest {
 
         assertFalse(SQLExceptionUtils.unwrapAndCheckForCode(wrapper, 1045));
     }
-
 
     @Test
     public void test_unwrapAndCheckForCode_loopInWrappedExceptions_returnsFalse() {

--- a/src/test/java/com/amazonaws/secretsmanager/util/TestClass.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/TestClass.java
@@ -12,17 +12,17 @@
  */
 package com.amazonaws.secretsmanager.util;
 
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-
 import java.util.Arrays;
 import java.util.LinkedList;
 
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+
 /**
- * A class that holds some helper methods for running tests that test classes should inherit from.
+ * A class that holds some helper methods for running tests that test classes
+ * should inherit from.
  */
 public class TestClass {
 
@@ -33,7 +33,7 @@ public class TestClass {
     }
 
     public Object getFieldFrom(Object o, String fieldName) {
-        Class clazz = o.getClass();
+        Class<?> clazz = o.getClass();
         boolean isDone = false;
         while (!isDone) {
             try {
@@ -61,7 +61,7 @@ public class TestClass {
     }
 
     public void setFieldFrom(Object o, String fieldName, Object value) {
-        Class clazz = o.getClass();
+        Class<?> clazz = o.getClass();
         boolean isDone = false;
         while (!isDone) {
             try {
@@ -81,9 +81,9 @@ public class TestClass {
         }
     }
 
-    public Constructor getConstructorWithNArguments(Class clazz, int n) {
-        Constructor[] ctors = clazz.getDeclaredConstructors();
-        Constructor ctor = null;
+    public Constructor<?> getConstructorWithNArguments(Class<?> clazz, int n) {
+        Constructor<?>[] ctors = clazz.getDeclaredConstructors();
+        Constructor<?> ctor = null;
         for (int i = 0; i < ctors.length; i++) {
             ctor = ctors[i];
             if (ctor.getGenericParameterTypes().length == n) {
@@ -93,36 +93,36 @@ public class TestClass {
         return ctor;
     }
 
-    public Object newInstance(Constructor ctor, Object... initargs) {
+    public Object newInstance(Constructor<?> ctor, Object... initargs) {
         try {
             ctor.setAccessible(true);
             return ctor.newInstance(initargs);
         } catch (RuntimeException e) {
             throw e;
-        } catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return null;
         }
     }
 
-    public Object callConstructorWithArguments(Class clazz, Object... initargs) {
-        Constructor ctor = getConstructorWithNArguments(clazz, initargs.length);
+    public Object callConstructorWithArguments(Class<?> clazz, Object... initargs) {
+        Constructor<?> ctor = getConstructorWithNArguments(clazz, initargs.length);
         return newInstance(ctor, initargs);
     }
 
-    public Object callConstructorWithArguments(int argsOffset, Class clazz, Object... initargs) {
-        Constructor ctor = getConstructorWithNArguments(clazz, initargs.length + argsOffset);
+    public Object callConstructorWithArguments(int argsOffset, Class<?> clazz, Object... initargs) {
+        Constructor<?> ctor = getConstructorWithNArguments(clazz, initargs.length + argsOffset);
         return newInstance(ctor, initargs);
     }
 
     public GetSecretValueRequest requestWithName(String secretName) {
-        return new GetSecretValueRequest().withSecretId(secretName);
+        return GetSecretValueRequest.builder().secretId(secretName).build();
     }
 
     public Object callMethodWithArguments(Object object, String methodName, Object... args) {
         try {
             LinkedList<Method> allMethods = new LinkedList<>();
-            Class clazz = object.getClass();
+            Class<?> clazz = object.getClass();
             while (!clazz.equals(Object.class)) {
                 Method[] methods = clazz.getDeclaredMethods();
                 allMethods.addAll(Arrays.asList(methods));
@@ -140,9 +140,9 @@ public class TestClass {
             }
             correctMethod.setAccessible(true);
             return correctMethod.invoke(object, args);
-        } catch(RuntimeException e) {
+        } catch (RuntimeException e) {
             throw e;
-        } catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return null;
         }
@@ -153,31 +153,33 @@ public class TestClass {
     }
 
     public void assertThrows(Class<? extends Exception> exception, throwingRunnable code) {
-        try  {
+        try {
             code.run();
             throw new RuntimeException("Should have thrown a " + exception.getName() + " but threw nothing.");
         } catch (Exception e) {
             if (!exception.isAssignableFrom(e.getClass())) {
                 e.printStackTrace();
-                throw new RuntimeException("Should have thrown a " + exception.getName() + " but threw " + e.getClass().getName());
+                throw new RuntimeException(
+                        "Should have thrown a " + exception.getName() + " but threw " + e.getClass().getName());
             }
         }
     }
 
     public void assertThrows(Exception exception, throwingRunnable code) {
-        try  {
+        try {
             code.run();
             throw new RuntimeException("Should have thrown a " + exception.getMessage() + " but threw nothing.");
         } catch (Exception e) {
             if (!exception.equals(e)) {
                 e.printStackTrace();
-                throw new RuntimeException("Should have thrown a " + exception.getMessage() + " but threw " + e.getClass().getName());
+                throw new RuntimeException(
+                        "Should have thrown a " + exception.getMessage() + " but threw " + e.getClass().getName());
             }
         }
     }
 
     public void assertNotThrows(throwingRunnable code) {
-        try  {
+        try {
             code.run();
         } catch (Exception e) {
             e.printStackTrace();
@@ -185,4 +187,3 @@ public class TestClass {
         }
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Provide a v2 version of the Secrets Manager JDBC Library. Version 2 uses the Secrets Manager Caching library v2 under the hood, which itself uses the AWS Secrets Manager client for Java v2. The major version upgrade be a drop-in replacement for customers. Version 1 and 2 will keep being maintained side-by-side.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
