### PR TITLE
Add PostgreSQL error code 28000 to authentication errors

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -37,7 +37,14 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
      *
      * See <a href="https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html">PostgreSQL documentation</a>.
      */
-    public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
+    public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE 		= "28P01";
+
+    /**
+     * When Alternating User rotation occurs than RDS Proxy (if it is in place) returns the following exception:
+     * 		org.postgresql.util.PSQLException: FATAL: This RDS proxy has no credentials for the role eps_np_clone. Check the credentials for this role and try again.
+     * 		sqlState: 28000 - errorCode: 0
+     */
+    public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION 	= "28000";
 
     /**
      * Set to postgresql.
@@ -106,7 +113,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
         if (e instanceof SQLException) {
             SQLException sqle = (SQLException) e;
             String sqlState = sqle.getSQLState();
-            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE);
+            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) || sqlState.equals(ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION);
         }
         return false;
     }

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -37,14 +37,14 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
      *
      * See <a href="https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html">PostgreSQL documentation</a>.
      */
-    public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE 		= "28P01";
+    public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
 
     /**
-     * When Alternating User rotation occurs than RDS Proxy (if it is in place) returns the following exception:
-     * 		org.postgresql.util.PSQLException: FATAL: This RDS proxy has no credentials for the role eps_np_clone. Check the credentials for this role and try again.
-     * 		sqlState: 28000 - errorCode: 0
+     * The error code returned by RDS Proxy when the secret is rotated in alternating user mode.
+     *
+     * See <a href="https://www.postgresql.org/docs/current/errcodes-appendix.html">PosgreSQL documentation</a>.
      */
-    public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION 	= "28000";
+    public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION = "28000";
 
     /**
      * Set to postgresql.


### PR DESCRIPTION
*Issue #222 *

*Description of changes:*
PostgreSQL Error Code 28000 is also considered as an authentication error in order to trigger secret refresh (together with 28P01 - invalid_password)

PostgreSQL Error Code 28000 (invalid_authorization_specification) is the error code returned by RDS Proxy when the secret is rotated in alternating user mode: refreshing the secret cache would address the issue #222.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
