### PR TITLE
Add PostgreSQL error code 28000 to authentication errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ jacoco.exec
 
 # VS Code
 .vscode/
+org.eclipse*

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -39,6 +39,13 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
     public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
 
     /**
+     * The error code returned by RDS Proxy when the secret is rotated in alternating user mode.
+     *
+     * See <a href="https://www.postgresql.org/docs/current/errcodes-appendix.html">PosgreSQL documentation</a>.
+     */
+    public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION = "28000";
+
+    /**
      * Set to postgresql.
      */
     public static final String SUBPREFIX = "postgresql";
@@ -105,7 +112,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
         if (e instanceof SQLException) {
             SQLException sqle = (SQLException) e;
             String sqlState = sqle.getSQLState();
-            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE);
+            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) || sqlState.equals(ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION);
         }
         return false;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

PostgreSQL Error Code 28000 is also considered as an authentication error

PostgreSQL Error Code 28000 is also considered as an authentication error in order to trigger secret refresh (together with 28P01 - invalid_password)

PostgreSQL Error Code 28000 (invalid_authorization_specification) is the error code returned by RDS Proxy when the secret is rotated in alternating user mode: refreshing the secret cache would address the issue https://github.com/aws/aws-secretsmanager-jdbc/issues/222.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
