### PR TITLE
chore: update/cleanup workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: Java Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, v2]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
 
 env:
   AWS_DEFAULT_REGION: us-west-2
@@ -10,13 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: 11
+          distribution: adopt
+
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
+
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,14 +40,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,20 +9,22 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: ["master", "v2"]
+    branches: [master, v2]
   pull_request:
-    branches: ["master", "v2"]
+    branches: [master, v2]
   schedule:
-    - cron: '38 2 * * 1'
+    - cron: "38 2 * * 1"
 
 jobs:
   analyze:
     name: Analyze
+
     runs-on: ubuntu-latest
+
     permissions:
       actions: read
       contents: read
@@ -31,20 +33,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language: [ 'java' ]
+        language: ["java"]
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Closes #263, #236, #234, #213
- Bump action versions
- Fix build workflow so that duplicate runs do not occur for PRs. Currently, the build workflow runs twice for each PR because it's set up to run on every push and PR
- Fix formatting

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
