### PR TITLE
Add optional shaded JAR build via Maven "shade" profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ This library is licensed under the Apache 2.0 License.
 
 ## Building from Source
 
-After you've downloaded the code from GitHub, you can build it using Maven. To disable GPG signing in the build, use this command: `mvn clean install -Dgpg.skip=true`
+After you've downloaded the code from GitHub, you can build it using Maven. 
+* To disable GPG signing in the build, use this command: `mvn clean install -Dgpg.skip=true`
+* To build the default (non-shaded) JAR, use this command: `mvn clean install`
+* To build the shaded (uber) JAR with all dependencies included, use this command: `mvn clean install -Pshade`
+The shaded JAR will be generated in the `target/` directory with the `-shaded` classifier, e.g.: `target/aws-secretsmanager-jdbc-2.0.2-shaded.jar`
 
 ## Usage
 The recommended way to use the SQL Connection Library is to consume it from Maven.  The latest released version can be found at: https://mvnrepository.com/artifact/com.amazonaws.secretsmanager/aws-secretsmanager-jdbc

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>shade</id>

--- a/pom.xml
+++ b/pom.xml
@@ -225,31 +225,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
-        <executions>
-          <execution>
-            <id>shade</id>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver</mainClass>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -282,6 +257,38 @@
               <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>shade</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>shade</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>shaded</shadedClassifierName>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver</mainClass>
+                    </transformer>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
             <configuration>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>
-              <createDeependencyReducedPom>false</createDeependencyReducedPom>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,31 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <createDeependencyReducedPom>false</createDeependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.4</version>
+            <version>3.6.0</version>
             <executions>
               <execution>
                 <id>shade</id>


### PR DESCRIPTION
*Issue #, if available:* #270

*Description of changes:* This PR adds optional support for building a shaded (uber) JAR using the Maven Shade Plugin. The shaded JAR includes all runtime dependencies, making it easier to use the library in tools or environments that do not support Maven-style dependency resolution.

*Key Changes*
* Added a new Maven profile named shade that generates a shaded JAR (aws-secretsmanager-jdbc-<version>-shaded.jar)
* Updated the README with instructions for using the shade profile

*Testing*
* Ensured the original (non-shaded) JAR remains the default output to avoid impacting normal builds via `mvn clean install`
* Ensured the shaded JAR gets created via `mvn clean install -Pshade`
* Verified shaded JAR loads AWSSecretsManagerPostgreSQLDriver via a standalone test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
