### PR TITLE
Remove PowerMock, Move to JUnit 5, target Java 8 again.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 env:
-  AWS_DEFAULT_REGION: us-west-2
+  AWS_REGION: us-west-2
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 17
+          distribution: corretto
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package

--- a/pom.xml
+++ b/pom.xml
@@ -70,20 +70,20 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>secretsmanager</artifactId>
-      <version>2.34.0</version>
+      <version>2.34.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.38</version>
+      <version>1.18.42</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.19.0</version>
+      <version>2.20.0</version>
     </dependency>
 
     <dependency>
@@ -235,7 +235,7 @@
             <plugin>
               <groupId>org.sonatype.central</groupId>
               <artifactId>central-publishing-maven-plugin</artifactId>
-              <version>0.8.0</version>
+              <version>0.9.0</version>
               <extensions>true</extensions>
               <configuration>
                 <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,8 @@
               <extensions>true</extensions>
               <configuration>
                 <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+                <waitUntil>published</waitUntil>
               </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,25 @@
       <version>5.18.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.4</version>
+        <configuration>
+          <argLine>-XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,15 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>5.2.0</version>
+      <artifactId>mockito-core</artifactId>
+      <version>5.18.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -89,27 +89,27 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.9.5</version>
+      <version>4.9.6</version>
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.12.2</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>2.1.8</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.12.4</version>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -121,8 +121,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -176,8 +175,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <!-- Pin to 4.8.5.0 as newer versions require JDK 11 -->
-        <version>4.8.5.0</version>
+        <version>4.9.6.0</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -70,26 +70,26 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>secretsmanager</artifactId>
-      <version>2.31.7</version>
+      <version>2.34.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.38</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.9.3</version>
+      <version>4.9.5</version>
     </dependency>
 
     <dependency>
@@ -112,20 +112,6 @@
       <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -133,10 +119,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.14.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -156,7 +142,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -190,7 +176,8 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.9.3.0</version>
+        <!-- Pin to 4.8.5.0 as newer versions require JDK 11 -->
+        <version>4.8.5.0</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>
@@ -209,7 +196,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <goals>
@@ -236,7 +223,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.7</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -250,7 +237,7 @@
             <plugin>
               <groupId>org.sonatype.central</groupId>
               <artifactId>central-publishing-maven-plugin</artifactId>
-              <version>0.7.0</version>
+              <version>0.8.0</version>
               <extensions>true</extensions>
               <configuration>
                 <publishingServerId>central</publishingServerId>
@@ -266,7 +253,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.1</version>
             <executions>
               <execution>
                 <id>shade</id>

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -133,7 +133,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      *
      * @param cache                                             Secret cache to use to retrieve secrets
      */
-    @SuppressFBWarnings({"MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR", "CT_CONSTRUCTOR_THROW"})
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     protected AWSSecretsManagerDriver(SecretCache cache) {
         this.secretCache = cache;
 

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
@@ -42,6 +42,9 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
      */
     public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
 
+    /**
+     * The Redshift JDBC sub-prefix.
+     */
     public static final String SUBPREFIX = "redshift";
 
     static {

--- a/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProvider.java
@@ -35,10 +35,17 @@ public class JDBCSecretCacheBuilderProvider {
 
     private Config configFile;
 
+    /**
+     * Constructs the provider with the default configuration.
+     */
     public JDBCSecretCacheBuilderProvider() {
         this(Config.loadMainConfig());
     }
 
+    /**
+     * Constructs the provider with the provided configuration.
+     * @param config Config to use for provider
+     */
     public JDBCSecretCacheBuilderProvider(Config config) {
         configFile = config;
     }

--- a/src/main/java/com/amazonaws/secretsmanager/util/SQLExceptionUtils.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/SQLExceptionUtils.java
@@ -4,6 +4,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * SQL Exception Utilities
+ */
 public class SQLExceptionUtils {
 
     /**

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
@@ -16,12 +16,8 @@ import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.SQLException;
 
@@ -32,9 +28,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the Db2 Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerDb2Driver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerDb2DriverTest extends TestClass {
 
     private AWSSecretsManagerDb2Driver sut;
@@ -45,7 +38,7 @@ public class AWSSecretsManagerDb2DriverTest extends TestClass {
     @Before
     public void setup() {
         System.setProperty("drivers.db2.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerDb2Driver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
@@ -14,16 +14,16 @@ package com.amazonaws.secretsmanager.sql;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.sql.SQLException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the Db2 Driver.
@@ -35,7 +35,7 @@ public class AWSSecretsManagerDb2DriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.db2.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.openMocks(this);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -25,15 +25,11 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
@@ -46,9 +42,6 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilde
  * Tests for AWSSecretsManagerDriver. Uses a config file in the resources folder just to make sure it can read from
  * the file.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor({"com.amazonaws.secretsmanager.sql.*"})
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerDriverTest extends TestClass {
 
     private AWSSecretsManagerDummyDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -12,19 +12,19 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -57,13 +57,13 @@ public class AWSSecretsManagerDriverTest extends TestClass {
 
     boolean hasRefreshed;
 
-    @Before
+    @BeforeEach
     public void setup() throws InterruptedException {
         System.clearProperty("drivers.dummy.realDriverClass");
 
         // Instantiate mocks
         hasRefreshed = false;
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.when(cache.getSecretString(Mockito.any(String.class))).thenAnswer(new Answer<String>() {
             @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
@@ -340,7 +340,7 @@ public class AWSSecretsManagerDriverTest extends TestClass {
     public void test_getPropertyInfo_propagatesToRealDriver() {
         String param1 = "jdbc-secretsmanager:expectedUrl";
         Properties param2 = new Properties();
-        assertNotThrows(() -> Assert.assertNull(sut.getPropertyInfo(param1, param2)));
+        assertNotThrows(() -> Assertions.assertNull(sut.getPropertyInfo(param1, param2)));
         assertEquals(1, DummyDriver.getPropertyInfoCallCount);
         String param1Expected = "jdbc:expectedUrl";
         assertEquals(param1Expected, DummyDriver.getPropertyInfoParam1);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,7 +36,7 @@ public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.sqlserver.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.openMocks(this);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the MSSQL Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMSSQLServerDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
 
     private AWSSecretsManagerMSSQLServerDriver sut;
@@ -46,7 +39,7 @@ public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
     @Before
     public void setup() {
         System.setProperty("drivers.sqlserver.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerMSSQLServerDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,10 +36,10 @@ public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.mariadb.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerMariaDBDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMariaDBDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the MariaDB Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMariaDBDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMariaDBDriverTest extends TestClass {
 
     private AWSSecretsManagerMariaDBDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the MySQL Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerMySQLDriverTest extends TestClass {
 
     private AWSSecretsManagerMySQLDriver sut;

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMySQLDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,10 +36,10 @@ public class AWSSecretsManagerMySQLDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.mysql.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerMySQLDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the Oracle Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerOracleDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerOracleDriverTest extends TestClass {
 
     private AWSSecretsManagerOracleDriver sut;
@@ -46,7 +39,7 @@ public class AWSSecretsManagerOracleDriverTest extends TestClass {
     @Before
     public void setup() {
         System.setProperty("drivers.oracle.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerOracleDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerOracleDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,7 +36,7 @@ public class AWSSecretsManagerOracleDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.oracle.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.openMocks(this);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,7 +36,7 @@ public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.postgresql.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.openMocks(this);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the PostgreSQL Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
 
     private AWSSecretsManagerPostgreSQLDriver sut;
@@ -46,7 +39,7 @@ public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
     @Before
     public void setup() {
         System.setProperty("drivers.postgresql.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerPostgreSQLDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
@@ -12,14 +12,14 @@
  */
 package com.amazonaws.secretsmanager.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,7 +36,7 @@ public class AWSSecretsManagerRedshiftDriverTest extends TestClass {
     @Mock
     private SecretCache cache;
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("drivers.redshift.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
         MockitoAnnotations.openMocks(this);

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
@@ -20,12 +20,8 @@ import java.sql.SQLException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.util.TestClass;
@@ -33,9 +29,6 @@ import com.amazonaws.secretsmanager.util.TestClass;
 /**
  * Tests for the Redshift Driver.
  */
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("com.amazonaws.secretsmanager.sql.AWSSecretsManagerRedshiftDriver")
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class AWSSecretsManagerRedshiftDriverTest extends TestClass {
 
     private AWSSecretsManagerRedshiftDriver sut;
@@ -46,7 +39,7 @@ public class AWSSecretsManagerRedshiftDriverTest extends TestClass {
     @Before
     public void setup() {
         System.setProperty("drivers.redshift.realDriverClass", "com.amazonaws.secretsmanager.sql.DummyDriver");
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         try {
             sut = new AWSSecretsManagerRedshiftDriver(cache);
         } catch (Exception e) {

--- a/src/test/java/com/amazonaws/secretsmanager/util/ConfigTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/ConfigTest.java
@@ -12,13 +12,13 @@
  */
 package com.amazonaws.secretsmanager.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the Config.

--- a/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
@@ -2,27 +2,29 @@ package com.amazonaws.secretsmanager.util;
 
 import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.PROPERTY_VPC_ENDPOINT_REGION;
 import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.PROPERTY_VPC_ENDPOINT_URL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import com.amazonaws.secretsmanager.sql.AWSSecretsManagerDriver;
 
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+@ExtendWith(SystemStubsExtension.class)
 public class JDBCSecretCacheBuilderProviderTest {
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     /**
      * SetRegion Tests.
@@ -122,8 +124,8 @@ public class JDBCSecretCacheBuilderProviderTest {
 
         SecretsManagerClient client = new JDBCSecretCacheBuilderProvider(configProvider).build().build();
 
-        assertNotEquals(client.serviceClientConfiguration().region(), Region.US_EAST_2);
-        assertEquals(client.serviceClientConfiguration().region(), Region.EU_WEST_3);
+        assertNotEquals(Region.US_EAST_2, client.serviceClientConfiguration().region());
+        assertEquals(Region.EU_WEST_3, client.serviceClientConfiguration().region());
     }
 
     /**
@@ -180,7 +182,7 @@ public class JDBCSecretCacheBuilderProviderTest {
         Config configProvider = mock(Config.class);
 
         String environmentRegionName = JDBCSecretCacheBuilderProvider.REGION_ENVIRONMENT_VARIABLE;
-        environmentVariables.clear(environmentRegionName);
+        environmentVariables.remove(environmentRegionName);
 
         try {
             new JDBCSecretCacheBuilderProvider(configProvider).build().build();

--- a/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/JDBCSecretCacheBuilderProviderTest.java
@@ -3,6 +3,7 @@ package com.amazonaws.secretsmanager.util;
 import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.PROPERTY_VPC_ENDPOINT_REGION;
 import static com.amazonaws.secretsmanager.util.JDBCSecretCacheBuilderProvider.PROPERTY_VPC_ENDPOINT_URL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -199,7 +200,7 @@ public class JDBCSecretCacheBuilderProviderTest {
 
         try {
             SecretsManagerClient client = new JDBCSecretCacheBuilderProvider(configProvider).build().build();
-            assertTrue(client.serviceClientConfiguration().endpointOverride().isEmpty());
+            assertFalse(client.serviceClientConfiguration().endpointOverride().isPresent());
         } catch (SdkClientException e) {
             assertTrue(e.getMessage().startsWith("Unable to load region from any of the providers in the chain"));
         }
@@ -216,7 +217,7 @@ public class JDBCSecretCacheBuilderProviderTest {
 
         try {
             SecretsManagerClient client = new JDBCSecretCacheBuilderProvider(configProvider).build().build();
-            assertTrue(client.serviceClientConfiguration().endpointOverride().isEmpty());
+            assertFalse(client.serviceClientConfiguration().endpointOverride().isPresent());
         } catch (SdkClientException e) {
             assertTrue(e.getMessage().startsWith("Unable to load region from any of the providers in the chain"));
         }

--- a/src/test/java/com/amazonaws/secretsmanager/util/SQLExceptionUtilsTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/util/SQLExceptionUtilsTest.java
@@ -1,11 +1,11 @@
 package com.amazonaws.secretsmanager.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SQLExceptionUtilsTest {
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Move to JUnit 5.
- Move to Mockito 5.
- Remove PowerMock.
- Moved from `system-rules` to `system-stubs-jupiter` since the first is not supported on JUnit 5.
- Updated all dependencies
- Updated the GitHub action workflow to build using JDK 17. (JDK 11 minimum is required for `system-rules-jupiter`, the library output is still Java 8 compatible.
- Set the `maven-compiler-plugin` target version to Java 8 using `release`. Explanation [here](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html).
- Enable auto-publish on the Maven sonatype plugin.
- Move from mockito-inline to mockito-core and its JUnit 5 plugin. The default mockmaker _is_ mockito-inline in Mockito 5.
- Silence some test warnings by enabling dynamic agent loading. Mockito and systemstubs use byte-buddy to intercept calls.

This also fixes code coverage output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
