### PR TITLE
Use OIDC for Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,10 @@ on:
 env:
   AWS_REGION: us-west-2
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,4 +33,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use the OIDC token to write code coverage data to Codecov.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
