### PR TITLE
fix: update dependencies to address CVE-2025-67735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,13 @@
     <dependency>
       <groupId>com.amazonaws.secretsmanager</groupId>
       <artifactId>aws-secretsmanager-caching-java</artifactId>
-      <version>2.0.0</version>
+      <version>2.1.1</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>secretsmanager</artifactId>
-      <version>2.34.2</version>
+      <version>2.41.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-secretsmanager-jdbc/issues/310

*Description of changes:*
- Updated `aws-secretsmanager-caching-java` from 2.0.0 to 2.1.1
- Updated `secretsmanager` SDK from 2.34.2 to 2.41.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
