### PR TITLE
Wait until release is uploaded to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
               <configuration>
                 <publishingServerId>central</publishingServerId>
                 <autoPublish>true</autoPublish>
-                <waitUntil>published</waitUntil>
+                <waitUntil>uploaded</waitUntil>
               </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Waiting for publication from Maven Central can take a long time (sometimes 20+min). Wait until the artifacts are uploaded, we will check that the release is published async. We have no straightforward course of action for delayed publication anyways.


### What is changing?

1. Changing the configuration of the sonatype release plugin to succeed after upload.


### Related Links

https://central.sonatype.org/publish/publish-portal-maven/#waituntil
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Identical to aws-secretsmanager-caching-java configuration.

### When testing locally, provide testing artifact(s):

1.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
