### PR TITLE
Expand auth error code detection for PGBouncer, MSSQL, and Db2 proxies

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2Driver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2Driver.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.utils.StringUtils;
  * </p>
  *
  * <p>
- * Configuration properties are specified using the "db2" subprefix (e.g drivers.mysql.realDriverClass).
+ * Configuration properties are specified using the "db2" subprefix (e.g drivers.db2.realDriverClass).
  * </p>
  */
 public final class AWSSecretsManagerDb2Driver extends AWSSecretsManagerDriver {
@@ -36,6 +36,13 @@ public final class AWSSecretsManagerDb2Driver extends AWSSecretsManagerDriver {
      * See <a href="https://www.ibm.com/docs/en/db2-for-zos/11?topic=codes-sql-error">Db2 error codes</a>.
      */
     public static final int ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = -1403;
+
+    /**
+     * The Db2 JDBC driver error code for connection authorization failure (User ID or Password invalid).
+     *
+     * See <a href="https://www.ibm.com/support/pages/why-db2-data-source-failing-connection-authorization-failure-occurred-reason-user-id-or-password-invalid-errorcode-4214-sqlstate28000">IBM Support</a>.
+     */
+    public static final int AUTH_ERROR = -4214;
 
     /**
      * Set to Db2.
@@ -101,7 +108,8 @@ public final class AWSSecretsManagerDb2Driver extends AWSSecretsManagerDriver {
 
     @Override
     public boolean isExceptionDueToAuthenticationError(Exception e) {
-        return SQLExceptionUtils.unwrapAndCheckForCode(e, ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE);
+        return SQLExceptionUtils.unwrapAndCheckForCode(e, ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE)
+            || SQLExceptionUtils.unwrapAndCheckForCode(e, AUTH_ERROR);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriver.java
@@ -43,6 +43,15 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
     public static final int LOGIN_FAILED = 18456;
 
     /**
+     * The MSSQLServer error code for when a user logs in from an untrusted domain.
+     *
+     * See
+     * <a href="https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-18452-database-engine-error">
+     * MSSQL Server error 18452</a>.
+     */
+    public static final int LOGIN_FAILED_UNTRUSTED_DOMAIN = 18452;
+
+    /**
      * Set to sqlserver.
      */
     public static final String SUBPREFIX = "sqlserver";
@@ -109,7 +118,7 @@ public final class AWSSecretsManagerMSSQLServerDriver extends AWSSecretsManagerD
         if (e instanceof SQLException) {
             SQLException sqle = (SQLException) e;
             int errorCode = sqle.getErrorCode();
-            return errorCode == LOGIN_FAILED;
+            return errorCode == LOGIN_FAILED || errorCode == LOGIN_FAILED_UNTRUSTED_DOMAIN;
         }
         return false;
     }

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriver.java
@@ -40,11 +40,25 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
     public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
 
     /**
-     * The error code returned by RDS Proxy when the secret is rotated in alternating user mode.
+     * The PostgreSQL error code for invalid authorization specification.
      *
-     * See <a href="https://www.postgresql.org/docs/current/errcodes-appendix.html">PosgreSQL documentation</a>.
+     * PostgreSQL returns 28000 for general authentication failures (e.g. pg_hba.conf rejection,
+     * certificate auth failure) as opposed to 28P01 which specifically indicates an invalid password.
+     *
+     * See <a href="https://www.postgresql.org/docs/current/errcodes-appendix.html">PostgreSQL documentation</a>.
      */
     public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION = "28000";
+
+    /**
+     * The error code returned by PGBouncer when serving a cached authentication failure.
+     *
+     * When a server login fails, PGBouncer's check_fast_fail() rejects subsequent clients
+     * with SQLSTATE 08P01 (protocol_violation) instead of the original 28P01 from PostgreSQL.
+     * This is PGBouncer's default SQLSTATE for all disconnect_client() calls.
+     *
+     * See <a href="https://github.com/pgbouncer/pgbouncer/blob/master/src/objects.c">PGBouncer check_fast_fail()</a>.
+     */
+    public static final String PGBOUNCER_AUTH_FAILURE = "08P01";
 
     /**
      * Set to postgresql.
@@ -113,7 +127,7 @@ public final class AWSSecretsManagerPostgreSQLDriver extends AWSSecretsManagerDr
         if (e instanceof SQLException) {
             SQLException sqle = (SQLException) e;
             String sqlState = sqle.getSQLState();
-            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) || sqlState.equals(ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION);
+            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) || sqlState.equals(ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION) || sqlState.equals(PGBOUNCER_AUTH_FAILURE);
         }
         return false;
     }

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriver.java
@@ -43,6 +43,27 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
     public static final String ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE = "28P01";
 
     /**
+     * The PostgreSQL error code for invalid authorization specification.
+     *
+     * PostgreSQL returns 28000 for general authentication failures (e.g. pg_hba.conf rejection,
+     * certificate auth failure) as opposed to 28P01 which specifically indicates an invalid password.
+     *
+     * See <a href="https://www.postgresql.org/docs/current/errcodes-appendix.html">PostgreSQL documentation</a>.
+     */
+    public static final String ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION = "28000";
+
+    /**
+     * The error code returned by PGBouncer when serving a cached authentication failure.
+     *
+     * When a server login fails, PGBouncer's check_fast_fail() rejects subsequent clients
+     * with SQLSTATE 08P01 (protocol_violation) instead of the original 28P01 from PostgreSQL.
+     * This is PGBouncer's default SQLSTATE for all disconnect_client() calls.
+     *
+     * See <a href="https://github.com/pgbouncer/pgbouncer/blob/master/src/objects.c">PGBouncer check_fast_fail()</a>.
+     */
+    public static final String PGBOUNCER_AUTH_FAILURE = "08P01";
+
+    /**
      * The Redshift JDBC sub-prefix.
      */
     public static final String SUBPREFIX = "redshift";
@@ -114,7 +135,7 @@ public final class AWSSecretsManagerRedshiftDriver extends AWSSecretsManagerDriv
         if (e instanceof SQLException) {
             SQLException sqle = (SQLException) e;
             String sqlState = sqle.getSQLState();
-            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE);
+            return sqlState.equals(ACCESS_DENIED_FOR_USER_USING_PASSWORD_TO_DATABASE) || sqlState.equals(ACCESS_DENIED_FOR_INVALID_AUTHORIZATION_SPECIFICATION) || sqlState.equals(PGBOUNCER_AUTH_FAILURE);
         }
         return false;
     }

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDb2DriverTest.java
@@ -59,6 +59,13 @@ public class AWSSecretsManagerDb2DriverTest extends TestClass {
     }
 
     @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_authError() {
+        SQLException e = new SQLException("auth failed", "", -4214);
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
         SQLException e = new SQLException("", "", -2323);
 

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerMSSQLServerDriverTest.java
@@ -60,6 +60,13 @@ public class AWSSecretsManagerMSSQLServerDriverTest extends TestClass {
     }
 
     @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_untrustedDomain() {
+        SQLException e = new SQLException("login failed", "", 18452);
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
         SQLException e = new SQLException("", "", 18457);
 

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerPostgreSQLDriverTest.java
@@ -60,6 +60,20 @@ public class AWSSecretsManagerPostgreSQLDriverTest extends TestClass {
     }
 
     @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_invalidAuthorizationSpecification() {
+        SQLException e = new SQLException("", "28000");
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_pgbouncerAuthFailure() {
+        SQLException e = new SQLException("cached error", "08P01");
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
         SQLException e = new SQLException("", "28P02");
 

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerRedshiftDriverTest.java
@@ -60,6 +60,20 @@ public class AWSSecretsManagerRedshiftDriverTest extends TestClass {
     }
 
     @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_invalidAuthorizationSpecification() {
+        SQLException e = new SQLException("", "28000");
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
+    public void test_isExceptionDueToAuthenticationError_returnsTrue_pgbouncerAuthFailure() {
+        SQLException e = new SQLException("cached error", "08P01");
+
+        assertTrue(sut.isExceptionDueToAuthenticationError(e));
+    }
+
+    @Test
     public void test_isExceptionDueToAuthenticationError_returnsFalse_wrongSQLException() {
         SQLException e = new SQLException("", "28P02");
 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Database connection poolers (e.g., PGBouncer) and middleware proxies may return different authentication error codes than the underlying database. The library only recognized a narrow set of hardcoded codes per driver, so unrecognized codes failed to trigger secret cache invalidation.


### What is changing?

1. PostgreSQL/Redshift: Added SQLSTATE 08P01 — PGBouncer's default error code when serving cached authentication failures via its check_fast_fail() path.
2. Redshift: Added missing SQLSTATE 28000 (invalid_authorization_specification), aligning with the PostgreSQL driver.
3. MSSQL: Added error code 18452 (login from untrusted domain) alongside the existing 18456 (invalid password).
4. Db2: Added error code -4214 (JDBC driver-level connection authorization failure) alongside the existing -1403 (SQL-level invalid password).
5. Javadoc fixes: Corrected inaccurate 28000 description, fixed drivers.mysql → drivers.db2 copy-paste error in Db2 class Javadoc, updated stale documentation links.
6. Tests: Added unit tests for all new error codes across all four drivers.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Added unit tests for each new error code.

### When testing locally, provide testing artifact(s):

1. `mvn clean test` output: `Tests run: 66, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS`

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
