### PR TITLE
Validate secret fields before JDBC URL construction

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -22,6 +22,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
@@ -107,6 +108,10 @@ public abstract class AWSSecretsManagerDriver implements Driver {
      * Message to return on the RuntimeException when secret string is invalid json
      */ 
     public static final String INVALID_SECRET_STRING_JSON = "Could not parse SecretString JSON";
+
+    private static final Pattern INVALID_HOST_PATTERN = Pattern.compile(".*[?#&;/@\\\\\\s].*");
+    private static final Pattern INVALID_DBNAME_PATTERN = Pattern.compile(".*[?#&;\\\\\\s].*");
+    private static final Pattern DIGITS_ONLY_PATTERN = Pattern.compile("\\d+");
 
     private SecretCache secretCache;
 
@@ -385,14 +390,14 @@ public abstract class AWSSecretsManagerDriver implements Driver {
         if (endpoint == null || endpoint.isEmpty()) {
             throw new SQLException("Secret 'host' field must not be null or empty.");
         }
-        if (endpoint.matches(".*[?#&;/@\\\\\\s].*")) {
+        if (INVALID_HOST_PATTERN.matcher(endpoint).matches()) {
             throw new SQLException("Secret 'host' field contains invalid characters. "
                     + "A valid host must be a hostname or IP address without URL special characters.");
         }
-        if (port != null && !port.isEmpty() && !port.matches("\\d+")) {
+        if (port != null && !port.isEmpty() && !DIGITS_ONLY_PATTERN.matcher(port).matches()) {
             throw new SQLException("Secret 'port' field must contain only digits.");
         }
-        if (dbname != null && !dbname.isEmpty() && dbname.matches(".*[?#&;\\\\\\s].*")) {
+        if (dbname != null && !dbname.isEmpty() && INVALID_DBNAME_PATTERN.matcher(dbname).matches()) {
             throw new SQLException("Secret 'dbname' field contains invalid characters.");
         }
     }

--- a/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
+++ b/src/main/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriver.java
@@ -377,6 +377,26 @@ public abstract class AWSSecretsManagerDriver implements Driver {
         throw new SQLException("Connect failed to authenticate: reached max connection retries");
     }
 
+    /**
+     * Validates that secret fields do not contain characters that could be used for URL injection.
+     * Prevents CWE-610 (Externally Controlled Reference to a Resource in Another Sphere).
+     */
+    private void validateSecretFields(String endpoint, String port, String dbname) throws SQLException {
+        if (endpoint == null || endpoint.isEmpty()) {
+            throw new SQLException("Secret 'host' field must not be null or empty.");
+        }
+        if (endpoint.matches(".*[?#&;/@\\\\\\s].*")) {
+            throw new SQLException("Secret 'host' field contains invalid characters. "
+                    + "A valid host must be a hostname or IP address without URL special characters.");
+        }
+        if (port != null && !port.isEmpty() && !port.matches("\\d+")) {
+            throw new SQLException("Secret 'port' field must contain only digits.");
+        }
+        if (dbname != null && !dbname.isEmpty() && dbname.matches(".*[?#&;\\\\\\s].*")) {
+            throw new SQLException("Secret 'dbname' field contains invalid characters.");
+        }
+    }
+
     @Override
     @SuppressFBWarnings("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
     public Connection connect(String url, Properties info) throws SQLException {
@@ -400,6 +420,7 @@ public abstract class AWSSecretsManagerDriver implements Driver {
                 String port = portNode == null ? null : portNode.asText();
                 JsonNode dbnameNode = jsonObject.get("dbname");
                 String dbname = dbnameNode == null ? null : dbnameNode.asText();
+                validateSecretFields(endpoint, port, dbname);
                 unwrappedUrl = constructUrlFromEndpointPortDatabase(endpoint, port, dbname);
             } catch (IOException e) {
                 // Most likely to occur in the event that the data is not JSON.

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -356,4 +356,88 @@ public class AWSSecretsManagerDriverTest extends TestClass {
         assertEquals(true, sut.jdbcCompliant());
         assertEquals(1, DummyDriver.jdbcCompliantCallCount);
     }
+
+    /*******************************************************************************************************************
+     * validateSecretFields Tests (URL Injection Prevention)
+     ******************************************************************************************************************/
+
+    @Test
+    public void test_connect_throws_hostWithFragment() {
+        Mockito.when(cache.getSecretString("MALICIOUS_HOST")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"evil.com:3306/x?allowLoadLocalInfile=true#\", \"port\": \"3306\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("MALICIOUS_HOST", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_throws_hostWithQuestionMark() {
+        Mockito.when(cache.getSecretString("MALICIOUS_HOST_Q")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"evil.com?param=val\", \"port\": \"3306\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("MALICIOUS_HOST_Q", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_throws_hostWithSlash() {
+        Mockito.when(cache.getSecretString("MALICIOUS_HOST_SLASH")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"evil.com/path\", \"port\": \"3306\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("MALICIOUS_HOST_SLASH", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_throws_hostWithAtSign() {
+        Mockito.when(cache.getSecretString("MALICIOUS_HOST_AT")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"user@evil.com\", \"port\": \"3306\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("MALICIOUS_HOST_AT", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_throws_nonNumericPort() {
+        Mockito.when(cache.getSecretString("BAD_PORT")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"valid.host.com\", \"port\": \"3306;inject\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("BAD_PORT", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_throws_dbnameWithFragment() {
+        Mockito.when(cache.getSecretString("BAD_DBNAME")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"valid.host.com\", \"port\": \"3306\", \"dbname\": \"db#fragment\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("BAD_DBNAME", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_works_validHostPortDbname() {
+        Mockito.when(cache.getSecretString("VALID_SECRET")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"mydb.us-east-1.rds.amazonaws.com\", \"port\": \"5432\", \"dbname\": \"prod\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertNotThrows(() -> sut.connect("VALID_SECRET", props));
+        assertEquals(1, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_works_nullPortAndDbname() {
+        Mockito.when(cache.getSecretString("MINIMAL_SECRET")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"localhost\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertNotThrows(() -> sut.connect("MINIMAL_SECRET", props));
+        assertEquals(1, DummyDriver.connectCallCount);
+    }
 }

--- a/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/sql/AWSSecretsManagerDriverTest.java
@@ -440,4 +440,24 @@ public class AWSSecretsManagerDriverTest extends TestClass {
         assertNotThrows(() -> sut.connect("MINIMAL_SECRET", props));
         assertEquals(1, DummyDriver.connectCallCount);
     }
+
+    @Test
+    public void test_connect_throws_emptyHost() {
+        Mockito.when(cache.getSecretString("EMPTY_HOST")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"\", \"port\": \"3306\", \"dbname\": \"test\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertThrows(SQLException.class, () -> sut.connect("EMPTY_HOST", props));
+        assertEquals(0, DummyDriver.connectCallCount);
+    }
+
+    @Test
+    public void test_connect_works_emptyPortAndDbname() {
+        Mockito.when(cache.getSecretString("EMPTY_OPTIONAL")).thenReturn(
+                "{\"username\": \"user\", \"password\": \"pass\", \"host\": \"valid.host.com\", \"port\": \"\", \"dbname\": \"\"}");
+        Properties props = new Properties();
+        props.setProperty("user", "user");
+        assertNotThrows(() -> sut.connect("EMPTY_OPTIONAL", props));
+        assertEquals(1, DummyDriver.connectCallCount);
+    }
 }


### PR DESCRIPTION
## Description

### Why is this change being made?

1. To prevent URL injection attacks (CWE-610) where malicious characters in secret fields could be used to manipulate JDBC URLs and bypass security controls or redirect connections to unintended databases.


### What is changing?

1. Added `validateSecretFields()` method in `AWSSecretsManagerDriver` that validates the `host`, `port`, and `dbname` fields from secrets before URL construction.


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. Added new test methods for this change.

### When testing locally, provide testing artifact(s):

1. `mvn clean test` `Tests run: 155, Failures: 0, Errors: 0, Skipped: 0`

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
