### PR TITLE
Matrix build on Java LTS versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,15 +16,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: ['8', '11', '17', '21', '25']
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: ${{ matrix.java }}
           distribution: corretto
+          cache: 'maven'
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17', '21', '25']
+        java: ['17', '21', '25']
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        java: ['8', '11', '17', '21', '25']
+        java: ['11', '17', '21', '25']
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Check that the JDBC library build succeeds on all LTS Java versions.
2. Cache dependencies for faster followup builds.


### What is changing?

1.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1.

### When testing locally, provide testing artifact(s):

1.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
